### PR TITLE
Implement streaming search results via SSE

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -11,10 +11,14 @@ export async function apiRequest(
   method: string,
   url: string,
   data?: unknown | undefined,
+  options?: { headers?: Record<string, string> },
 ): Promise<Response> {
   const res = await fetch(url, {
     method,
-    headers: data ? { "Content-Type": "application/json" } : {},
+    headers: {
+      ...(data ? { "Content-Type": "application/json" } : {}),
+      ...(options?.headers || {}),
+    },
     body: data ? JSON.stringify(data) : undefined,
     credentials: "include",
   });


### PR DESCRIPTION
## Summary
- support SSE streaming in `/api/search`
- allow custom headers when making API requests
- expose `searchAIStream` to consume the SSE
- update search results page to display streamed results

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*