### PR TITLE
Update branding to VistAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# AISearch - Multi-LLM Search Platform
+# VistAI - Multi-LLM Search Platform
 
-AISearch is a platform that aggregates responses from various language models via OpenRouter, providing a unified and intuitive search experience.
+VistAI is a platform that aggregates responses from various language models via OpenRouter, providing a unified and intuitive search experience.
 
 ## ⚠️ IMPORTANT: How to Run the Application
 

--- a/client/index.html
+++ b/client/index.html
@@ -4,15 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
     <meta name="description" content="AI Search Engine - Compare results from different AI models in one search. Find the best AI answers to your questions." />
-    <title>AISearch - Multi-LLM Search Engine</title>
+    <title>VistAI - Multi-LLM Search Engine</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
     <!-- Open Graph tags for better social sharing -->
-    <meta property="og:title" content="AISearch - Multi-LLM Search Engine" />
+    <meta property="og:title" content="VistAI - Multi-LLM Search Engine" />
     <meta property="og:description" content="Compare results from leading AI models in one search. Find the best AI answers to your questions." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://aisearch.replit.app" />
+    <meta property="og:url" content="https://vistai.replit.app" />
   </head>
   <body>
     <div id="root"></div>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -61,7 +61,7 @@ function MainApp() {
       {/* Header */}
       <header className="sticky top-0 z-10 border-b border-border bg-background">
         <div className="container mx-auto px-4 py-3 flex items-center">
-          <h1 className="text-xl font-bold text-primary mr-4">AISearch</h1>
+          <h1 className="text-xl font-bold text-primary mr-4">VistAI</h1>
           
           {hasSearched && (
             <form onSubmit={handleSearch} className="flex-1 max-w-xl">

--- a/client/src/SimplePage.tsx
+++ b/client/src/SimplePage.tsx
@@ -51,7 +51,7 @@ export default function SimplePage() {
               onClick={() => setSearchPerformed(false)}
               className="flex items-center gap-2"
             >
-              <h1 className="text-xl font-bold text-primary">AISearch</h1>
+              <h1 className="text-xl font-bold text-primary">VistAI</h1>
               <span className="text-xs bg-card px-2 py-0.5 rounded-full text-muted-foreground">Beta</span>
             </button>
           </div>
@@ -253,7 +253,7 @@ export default function SimplePage() {
           <div className="flex flex-col md:flex-row justify-between items-center gap-4">
             <div className="text-muted-foreground text-sm">
               <p>
-                © {new Date().getFullYear()} AISearch • 
+                © {new Date().getFullYear()} VistAI • 
                 <button className="hover:text-primary ml-1">Terms</button> • 
                 <button className="hover:text-primary ml-1">Privacy</button>
               </p>

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -9,7 +9,7 @@ export default function Footer({ onNavigate }: FooterProps) {
         <div className="flex flex-col md:flex-row justify-between items-center gap-4">
           <div className="text-muted-foreground text-sm">
             <p>
-              © {new Date().getFullYear()} AISearch • 
+              © {new Date().getFullYear()} VistAI • 
               <button className="hover:text-primary ml-1">Terms</button> • 
               <button className="hover:text-primary ml-1">Privacy</button>
             </p>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -35,7 +35,7 @@ export default function Header({ currentPage, onNavigate }: HeaderProps) {
             onClick={() => onNavigate("home")}
             className="flex items-center gap-2"
           >
-            <h1 className="text-xl font-bold text-primary">AISearch</h1>
+            <h1 className="text-xl font-bold text-primary">VistAI</h1>
             <span className="text-xs bg-card px-2 py-0.5 rounded-full text-muted-foreground">Beta</span>
           </button>
         </div>

--- a/client/src/components/SubscriptionModal.tsx
+++ b/client/src/components/SubscriptionModal.tsx
@@ -23,7 +23,7 @@ export default function SubscriptionModal({
         <DialogHeader>
           <DialogTitle className="text-xl font-bold text-foreground">Upgrade Your Experience</DialogTitle>
           <DialogDescription className="text-muted-foreground">
-            Subscribe to AISearch Pro and support your favorite AI models. We share revenue with the models you use most frequently.
+            Subscribe to VistAI Pro and support your favorite AI models. We share revenue with the models you use most frequently.
           </DialogDescription>
         </DialogHeader>
         

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -195,7 +195,7 @@ export default function Dashboard() {
           <div className="flex items-center justify-between">
             <div>
               <p className="text-sm text-muted-foreground mb-1">
-                Subscribe to AISearch Pro and support your favorite AI models. We share revenue with the models you use most frequently.
+                Subscribe to VistAI Pro and support your favorite AI models. We share revenue with the models you use most frequently.
               </p>
               <p className="text-xs text-muted-foreground">
                 Starting at $9.99/month

--- a/index.cjs
+++ b/index.cjs
@@ -9,7 +9,7 @@ const HTML = `
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AISearch</title>
+  <title>VistAI</title>
   <style>
     body { 
       font-family: system-ui, -apple-system, sans-serif; 
@@ -139,7 +139,7 @@ const HTML = `
   <div id="results" class="results"></div>
   
   <div class="footer">
-    &copy; 2025 AISearch • Powered by OpenRouter
+    &copy; 2025 VistAI • Powered by OpenRouter
   </div>
   
   <div id="status" class="status"></div>
@@ -263,7 +263,7 @@ http.createServer(async (req, res) => {
                   headers: {
                     "Content-Type": "application/json",
                     "Authorization": `Bearer ${API_KEY}`,
-                    "HTTP-Referer": "https://aisearch.replit.app",
+                    "HTTP-Referer": "https://vistai.replit.app",
                     "X-Title": "AI Search Engine"
                   },
                   body: JSON.stringify({

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AISearch - Multi-LLM Search Engine</title>
+  <title>VistAI - Multi-LLM Search Engine</title>
   <meta name="description" content="Compare responses from multiple AI models in one search">
   
   <style>
@@ -253,7 +253,7 @@
     </div>
     
     <footer class="footer">
-      <p>&copy; 2025 AISearch • Powered by OpenRouter API</p>
+      <p>&copy; 2025 VistAI • Powered by OpenRouter API</p>
       <p style="margin-top: 5px; font-size: 12px;">Results are provided by various AI models and may vary in accuracy and content</p>
     </footer>
   </div>

--- a/launch-aisearch.js
+++ b/launch-aisearch.js
@@ -21,7 +21,7 @@ const htmlContent = `<!DOCTYPE html>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AISearch - Compare AI Model Responses</title>
+  <title>VistAI - Compare AI Model Responses</title>
   <meta name="description" content="Search across multiple AI models to compare responses">
   
   <style>
@@ -261,7 +261,7 @@ const htmlContent = `<!DOCTYPE html>
     </div>
     
     <footer class="footer">
-      <p>&copy; 2025 AISearch • Powered by OpenRouter API</p>
+      <p>&copy; 2025 VistAI • Powered by OpenRouter API</p>
       <p style="margin-top: 5px; font-size: 12px;">Results are provided by various AI models and may vary in accuracy and content</p>
     </footer>
   </div>
@@ -475,7 +475,7 @@ const server = http.createServer(async (req, res) => {
                   headers: {
                     "Content-Type": "application/json",
                     "Authorization": `Bearer ${API_KEY}`,
-                    "HTTP-Referer": "https://aisearch.replit.app",
+                    "HTTP-Referer": "https://vistai.replit.app",
                     "X-Title": "AI Search Engine"
                   },
                   body: JSON.stringify({

--- a/minimal-server.cjs
+++ b/minimal-server.cjs
@@ -14,7 +14,7 @@ const MINIMAL_HTML = `
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AISearch</title>
+    <title>VistAI</title>
     <style>
       body { 
         font-family: Arial, sans-serif; 
@@ -86,7 +86,7 @@ const MINIMAL_HTML = `
     </style>
   </head>
   <body>
-    <h1>AISearch</h1>
+    <h1>VistAI</h1>
     <p>Compare responses from multiple AI models</p>
     
     <div class="search-container">
@@ -212,7 +212,7 @@ http.createServer(async (req, res) => {
                   headers: {
                     "Content-Type": "application/json",
                     "Authorization": `Bearer ${API_KEY}`,
-                    "HTTP-Referer": "https://aisearch.replit.app",
+                    "HTTP-Referer": "https://vistai.replit.app",
                     "X-Title": "AI Search Engine"
                   },
                   body: JSON.stringify({

--- a/server-entrypoint.js
+++ b/server-entrypoint.js
@@ -110,7 +110,7 @@ const server = http.createServer(async (req, res) => {
                   headers: {
                     "Content-Type": "application/json",
                     "Authorization": `Bearer ${API_KEY}`,
-                    "HTTP-Referer": "https://aisearch.replit.app",
+                    "HTTP-Referer": "https://vistai.replit.app",
                     "X-Title": "AI Search Engine"
                   },
                   body: JSON.stringify({

--- a/server-no-dependencies.cjs
+++ b/server-no-dependencies.cjs
@@ -57,7 +57,7 @@ const server = http.createServer((req, res) => {
                   headers: {
                     "Content-Type": "application/json",
                     "Authorization": `Bearer ${API_KEY}`,
-                    "HTTP-Referer": "https://aisearch.replit.app",
+                    "HTTP-Referer": "https://vistai.replit.app",
                     "X-Title": "AI Search Engine"
                   },
                   body: JSON.stringify({
@@ -191,7 +191,7 @@ const server = http.createServer((req, res) => {
         <head>
           <meta charset="UTF-8">
           <meta name="viewport" content="width=device-width, initial-scale=1.0">
-          <title>AISearch</title>
+          <title>VistAI</title>
           <style>
             body { font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; }
             h1 { color: #9333EA; }
@@ -202,7 +202,7 @@ const server = http.createServer((req, res) => {
           </style>
         </head>
         <body>
-          <h1>AISearch</h1>
+          <h1>VistAI</h1>
           <p>Search across multiple AI models</p>
           
           <div>

--- a/server.js
+++ b/server.js
@@ -87,7 +87,7 @@ const server = http.createServer(async (req, res) => {
                   headers: {
                     "Content-Type": "application/json",
                     "Authorization": `Bearer ${API_KEY}`,
-                    "HTTP-Referer": "https://aisearch.replit.app",
+                    "HTTP-Referer": "https://vistai.replit.app",
                     "X-Title": "AI Search Engine"
                   },
                   body: JSON.stringify({

--- a/server/api-server.ts
+++ b/server/api-server.ts
@@ -20,7 +20,7 @@ async function queryOpenRouter(prompt: string, modelId: string) {
       headers: {
         "Content-Type": "application/json",
         "Authorization": `Bearer ${API_KEY}`,
-        "HTTP-Referer": "https://aisearch.replit.app",
+        "HTTP-Referer": "https://vistai.replit.app",
         "X-Title": "AI Search Engine"
       },
       body: JSON.stringify({

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -19,7 +19,7 @@ async function queryOpenRouter(prompt: string, modelId: string) {
       headers: {
         "Content-Type": "application/json",
         "Authorization": `Bearer ${API_KEY}`,
-        "HTTP-Referer": "https://aisearch.replit.app", // Adjust based on your app's domain
+        "HTTP-Referer": "https://vistai.replit.app", // Adjust based on your app's domain
         "X-Title": "AI Search Engine"
       },
       body: JSON.stringify({

--- a/server/simple-index.ts
+++ b/server/simple-index.ts
@@ -24,7 +24,7 @@ async function queryOpenRouter(prompt: string, modelId: string) {
       headers: {
         "Content-Type": "application/json",
         "Authorization": `Bearer ${API_KEY}`,
-        "HTTP-Referer": "https://aisearch.replit.app",
+        "HTTP-Referer": "https://vistai.replit.app",
         "X-Title": "AI Search Engine"
       },
       body: JSON.stringify({

--- a/server/static-app.ts
+++ b/server/static-app.ts
@@ -146,7 +146,7 @@ async function queryOpenRouter(prompt: string, modelId: string) {
       headers: {
         "Content-Type": "application/json",
         "Authorization": `Bearer ${API_KEY}`,
-        "HTTP-Referer": "https://aisearch.replit.app", // Adjust based on your app's domain
+        "HTTP-Referer": "https://vistai.replit.app", // Adjust based on your app's domain
         "X-Title": "AI Search Engine"
       },
       body: JSON.stringify({

--- a/server/static-index.html
+++ b/server/static-index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AISearch - Multi-LLM Search Engine</title>
+  <title>VistAI - Multi-LLM Search Engine</title>
   <meta name="description" content="Compare results from leading AI models in one search">
   
   <!-- Tailwind CDN -->
@@ -175,7 +175,7 @@
     <!-- Header -->
     <header class="sticky top-0 z-10 border-b border-[var(--border)] bg-[var(--background)]">
       <div class="container mx-auto px-4 py-3 flex justify-between items-center">
-        <h1 class="text-xl font-bold text-[var(--primary)]">AISearch</h1>
+        <h1 class="text-xl font-bold text-[var(--primary)]">VistAI</h1>
         
         <div id="header-search" class="hidden md:block w-[400px]">
           <!-- Will be populated when search is performed -->
@@ -246,7 +246,7 @@
         <div class="flex flex-col md:flex-row justify-between items-center gap-4">
           <div class="text-[var(--text-muted)] text-sm">
             <p>
-              © 2025 AISearch • 
+              © 2025 VistAI • 
               <button class="hover:text-[var(--primary)]">Terms</button> • 
               <button class="hover:text-[var(--primary)]">Privacy</button>
             </p>

--- a/simple-server.cjs
+++ b/simple-server.cjs
@@ -17,7 +17,7 @@ let indexHtml = `
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AISearch - Multi-LLM Search Engine</title>
+  <title>VistAI - Multi-LLM Search Engine</title>
   <meta name="description" content="Compare responses from multiple AI models in one search">
   
   <style>
@@ -267,7 +267,7 @@ let indexHtml = `
     </div>
     
     <footer class="footer">
-      <p>&copy; 2025 AISearch • Powered by OpenRouter API</p>
+      <p>&copy; 2025 VistAI • Powered by OpenRouter API</p>
       <p style="margin-top: 5px; font-size: 12px;">Results are provided by various AI models and may vary in accuracy and content</p>
     </footer>
   </div>
@@ -483,7 +483,7 @@ const server = http.createServer(async (req, res) => {
                   headers: {
                     "Content-Type": "application/json",
                     "Authorization": `Bearer ${API_KEY}`,
-                    "HTTP-Referer": "https://aisearch.replit.app",
+                    "HTTP-Referer": "https://vistai.replit.app",
                     "X-Title": "AI Search Engine"
                   },
                   body: JSON.stringify({

--- a/standalone-server.js
+++ b/standalone-server.js
@@ -31,7 +31,7 @@ async function queryOpenRouter(prompt, modelId) {
       headers: {
         "Content-Type": "application/json",
         "Authorization": `Bearer ${API_KEY}`,
-        "HTTP-Referer": "https://aisearch.replit.app",
+        "HTTP-Referer": "https://vistai.replit.app",
         "X-Title": "AI Search Engine"
       },
       body: JSON.stringify({

--- a/standalone-server.mjs
+++ b/standalone-server.mjs
@@ -36,7 +36,7 @@ async function queryOpenRouter(prompt, modelId) {
       headers: {
         "Content-Type": "application/json",
         "Authorization": `Bearer ${API_KEY}`,
-        "HTTP-Referer": "https://aisearch.replit.app",
+        "HTTP-Referer": "https://vistai.replit.app",
         "X-Title": "AI Search Engine"
       },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
- rename AISearch references to VistAI across the codebase
- update Open Graph metadata
- switch HTTP Referer URLs to vistai.replit.app

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*