### PR TITLE
Add Cloudflare Worker and Pages deployment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,11 @@ Future enhancements could include:
 - User accounts and personalized model rankings
 - Adding more AI models to the comparison
 - Implementing revenue sharing based on user preferences
+
+## Deploying to Cloudflare
+
+1. Deploy the static frontend using **Cloudflare Pages**. When configuring the Pages deployment, set an environment variable `API_BASE_URL` to the public URL of your Worker (for example `https://vistai-worker.yourdomain.workers.dev`). The frontend reads this value at runtime and prefixes all API requests with it.
+
+2. Deploy the API using **Cloudflare Workers** with `wrangler`. A sample `wrangler.toml` is included in this repository.
+
+Once both are deployed the site will automatically call the Worker endpoints via the configured base URL.

--- a/index.html
+++ b/index.html
@@ -258,6 +258,7 @@
     </footer>
   </div>
   
+
   <div id="api-status" class="api-status">API Status: Checking...</div>
   
   <script>
@@ -266,11 +267,14 @@
     const searchButton = document.getElementById('search-button');
     const resultsContainer = document.getElementById('results');
     const apiStatus = document.getElementById('api-status');
+
+    // Base URL for API requests; can be configured via window.API_BASE_URL
+    const API_BASE = window.API_BASE_URL ?? '';
     
     // Check API status
     async function checkApiStatus() {
       try {
-        const response = await fetch('/api/status');
+        const response = await fetch(`${API_BASE}/api/status`);
         if (response.ok) {
           const data = await response.json();
           apiStatus.textContent = `API Status: ${data.apiKey ? 'Connected' : 'Not configured'}`;
@@ -353,7 +357,7 @@
       
       try {
         // Make search request
-        const response = await fetch('/api/search', {
+        const response = await fetch(`${API_BASE}/api/search`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json'

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1,0 +1,218 @@
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const { pathname, searchParams } = url;
+
+    // Basic CORS support
+    const headers = {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    };
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { headers });
+    }
+
+    // In-memory storage persisted across requests while worker is warm
+    env.storage = env.storage || createStorage();
+
+    try {
+      if (pathname === '/api/status' && request.method === 'GET') {
+        return jsonResponse({
+          status: 'ok',
+          apiKey: Boolean(env.OPENROUTER_API_KEY),
+          time: new Date().toISOString(),
+        }, headers);
+      }
+
+      if (pathname === '/api/search' && request.method === 'POST') {
+        const body = await request.json();
+        const { query } = body;
+        if (!query) {
+          return jsonResponse({ message: 'Invalid search query' }, headers, 400);
+        }
+
+        const search = env.storage.createSearch({ query });
+        const models = [
+          'openai/gpt-4',
+          'anthropic/claude-2',
+          'meta-llama/llama-2-70b-chat',
+          'mistralai/mistral-7b-instruct',
+        ];
+
+        for (const m of models) {
+          env.storage.incrementModelSearches(m);
+        }
+
+        const results = [];
+        for (const modelId of models) {
+          const modelResponse = await queryOpenRouter(query, modelId, env.OPENROUTER_API_KEY);
+          const result = env.storage.createResult({
+            searchId: search.id,
+            modelId,
+            content: modelResponse.content,
+            title: modelResponse.title,
+            responseTime: modelResponse.responseTime,
+          });
+          results.push({ ...result, modelName: modelId.split('/').pop() });
+        }
+
+        return jsonResponse({
+          search,
+          results,
+          totalTime: Math.max(...results.map(r => r.responseTime || 0)),
+        }, headers);
+      }
+
+      if (pathname === '/api/track-click' && request.method === 'POST') {
+        const body = await request.json();
+        const { resultId } = body;
+        if (typeof resultId !== 'number') {
+          return jsonResponse({ message: 'Invalid click data' }, headers, 400);
+        }
+        const click = env.storage.trackClick({ resultId });
+        const stats = env.storage.getModelStats();
+        return jsonResponse({ success: true, click, stats }, headers);
+      }
+
+      if (pathname === '/api/model-stats' && request.method === 'GET') {
+        const stats = env.storage.getModelStatsWithPercent();
+        return jsonResponse(stats, headers);
+      }
+
+      if (pathname === '/api/top-models' && request.method === 'GET') {
+        const limit = parseInt(searchParams.get('limit') || '5', 10);
+        const stats = env.storage.getTopModelsWithPercent(limit);
+        return jsonResponse(stats, headers);
+      }
+
+      return new Response('Not Found', { status: 404, headers });
+    } catch (err) {
+      return jsonResponse({ message: 'Internal Error' }, headers, 500);
+    }
+  }
+};
+
+function jsonResponse(data, headers, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+function createStorage() {
+  let searchId = 1;
+  let resultId = 1;
+  let clickId = 1;
+  const searches = new Map();
+  const results = new Map();
+  const modelStats = new Map();
+
+  const defaultModels = [
+    'openai/gpt-4',
+    'anthropic/claude-2',
+    'meta-llama/llama-2-70b-chat',
+    'mistralai/mistral-7b-instruct',
+  ];
+  defaultModels.forEach((m) => {
+    modelStats.set(m, { id: searchId++, modelId: m, clickCount: 0, searchCount: 0, updatedAt: new Date() });
+  });
+
+  return {
+    createSearch({ query }) {
+      const s = { id: searchId++, query, createdAt: new Date() };
+      searches.set(s.id, s);
+      return s;
+    },
+    createResult({ searchId, modelId, content, title, responseTime }) {
+      const r = { id: resultId++, searchId, modelId, content, title, responseTime, createdAt: new Date() };
+      results.set(r.id, r);
+      return r;
+    },
+    trackClick({ resultId }) {
+      const r = results.get(resultId);
+      if (r) {
+        const stat = modelStats.get(r.modelId);
+        if (stat) {
+          stat.clickCount += 1;
+          stat.updatedAt = new Date();
+        }
+      }
+      const c = { id: clickId++, resultId, createdAt: new Date() };
+      return c;
+    },
+    incrementModelSearches(modelId) {
+      const stat = modelStats.get(modelId);
+      if (stat) {
+        stat.searchCount += 1;
+        stat.updatedAt = new Date();
+      }
+    },
+    getModelStats() {
+      return Array.from(modelStats.values());
+    },
+    getModelStatsWithPercent() {
+      const stats = this.getModelStats();
+      const totalClicks = stats.reduce((sum, s) => sum + s.clickCount, 0);
+      return stats.map((s) => ({
+        ...s,
+        percentage: totalClicks > 0 ? Math.round((s.clickCount / totalClicks) * 100) : 0,
+        displayName: s.modelId.split('/').pop(),
+      }));
+    },
+    getTopModelsWithPercent(limit) {
+      const stats = this.getModelStats()
+        .sort((a, b) => b.clickCount - a.clickCount)
+        .slice(0, limit);
+      const totalClicks = stats.reduce((sum, s) => sum + s.clickCount, 0);
+      return stats.map((s) => ({
+        ...s,
+        percentage: totalClicks > 0 ? Math.round((s.clickCount / totalClicks) * 100) : 0,
+        displayName: s.modelId.split('/').pop(),
+      }));
+    },
+  };
+}
+
+async function queryOpenRouter(prompt, modelId, apiKey) {
+  try {
+    if (!apiKey) throw new Error('OpenRouter API key is not configured');
+    const resp = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+        'HTTP-Referer': 'https://aisearch.example',
+        'X-Title': 'AI Search Engine',
+      },
+      body: JSON.stringify({
+        model: modelId,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+    if (!resp.ok) {
+      const txt = await resp.text();
+      throw new Error(`OpenRouter API error: ${resp.status} - ${txt}`);
+    }
+    const data = await resp.json();
+    return {
+      content: data.choices[0]?.message?.content || 'No response from model',
+      title: extractTitle(data.choices[0]?.message?.content),
+      responseTime: Math.round(data.usage?.total_ms || 0),
+    };
+  } catch (err) {
+    return { content: `Error getting response from ${modelId}: ${err.message}`, title: `Error from ${modelId}`, responseTime: 0 };
+  }
+}
+
+function extractTitle(content = '') {
+  const match = content.match(/^#\s+(.*?)$|^Title:\s*(.*?)$|^(.*?)[\n\r]/m);
+  if (match) {
+    for (let i = 1; i < match.length; i++) {
+      if (match[i]) return match[i].trim();
+    }
+  }
+  const words = content.split(/\s+/).slice(0, 5).join(' ');
+  return words + (words.length < content.length ? '...' : '');
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,6 @@
+name = "vistai-worker"
+main = "worker/worker.js"
+compatibility_date = "2024-06-05"
+
+[vars]
+# OPENROUTER_API_KEY should be set in the Cloudflare dashboard or via wrangler


### PR DESCRIPTION
## Summary
- enable configurable `API_BASE` on the static front-end
- add deployment instructions for Cloudflare
- provide Worker implementation for API endpoints
- ship example `wrangler.toml`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*