### PR TITLE
Add OpenRouter secret instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,6 @@ Set the build command to `npm run build` so the Vite CLI is available.
 
 2. Deploy the API using **Cloudflare Workers** with `wrangler`. A sample `wrangler.toml` is included in this repository.
 
+3. Set your OpenRouter API key as a secret for the Worker. Run `wrangler secret put OPENROUTER_API_KEY` or add the variable under **Settings > Variables** in the Cloudflare dashboard so the Worker can authenticate with OpenRouter.
+
 Once both are deployed the site will automatically call the Worker endpoints via the configured base URL.


### PR DESCRIPTION
## Summary
- explain how to set `OPENROUTER_API_KEY` when deploying the Worker on Cloudflare

## Testing
- `npm run check` *(fails: Could not find a declaration file for module './App.jsx', etc.)*
- `npm test` *(fails: Missing script "test")*