### PR TITLE
Update click tracking stats

### DIFF
--- a/client/src/components/ResultCard.tsx
+++ b/client/src/components/ResultCard.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardFooter } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -14,12 +15,20 @@ interface ResultCardProps {
 
 export default function ResultCard({ result }: ResultCardProps) {
   const { toast } = useToast();
+  const queryClient = useQueryClient();
   const [copied, setCopied] = useState(false);
   const [feedback, setFeedback] = useState<"liked" | "disliked" | null>(null);
   
   // Track click on result
   const handleContentClick = () => {
     trackResultClick(result.id)
+      .then((stats) => {
+        queryClient.setQueryData(["/api/model-stats"], stats);
+        toast({
+          title: "Click recorded",
+          description: "Model statistics updated",
+        });
+      })
       .catch((error) => {
         console.error("Failed to track click:", error);
       });

--- a/client/src/lib/openrouter.ts
+++ b/client/src/lib/openrouter.ts
@@ -107,11 +107,23 @@ export async function searchAIStream(
 }
 
 // Track when a user clicks on a result
-export async function trackResultClick(resultId: number, userId?: number): Promise<void> {
-  await apiRequest("POST", "/api/track-click", { 
+export interface TrackClickResponse {
+  success: boolean;
+  click: unknown;
+  stats: ModelStats[];
+}
+
+export async function trackResultClick(
+  resultId: number,
+  userId?: number,
+): Promise<ModelStats[]> {
+  const res = await apiRequest("POST", "/api/track-click", {
     resultId,
-    userId
+    userId,
   });
+
+  const data: TrackClickResponse = await res.json();
+  return data.stats;
 }
 
 // Get model performance statistics


### PR DESCRIPTION
## Summary
- return updated stats when tracking a result click
- update query cache and show toast when a result is clicked

## Testing
- `npm run check` *(fails: Could not find some declaration files and other TS errors)*