### PR TITLE
Graceful handling for missing OpenRouter key

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ If you encounter any issues:
 3. If needed, kill existing processes with `pkill node`
 4. Restart the standalone server with `./start.sh`
 
+## Environment Variables
+
+Set the `OPENROUTER_API_KEY` variable with your OpenRouter API key before starting a server:
+
+```bash
+export OPENROUTER_API_KEY=your-key
+./start.sh
+```
+If the variable is missing, the application logs a warning and every model query returns a structured error payload.
+
 ## Project Structure
 
 - `minimal-server.cjs`: A completely standalone implementation that works in Replit

--- a/minimal-server.cjs
+++ b/minimal-server.cjs
@@ -329,7 +329,11 @@ http.createServer(async (req, res) => {
   
 }).listen(PORT, '0.0.0.0', () => {
   console.log(`Minimal server running on port ${PORT}`);
-  console.log(`OpenRouter API Key configured: ${!!API_KEY}`);
+  const hasKey = !!API_KEY;
+  console.log(`OpenRouter API Key configured: ${hasKey}`);
+  if (!hasKey) {
+    console.warn('OPENROUTER_API_KEY is not set - using mock responses');
+  }
   console.log(`Server time: ${new Date().toISOString()}`);
   console.log(`View app at: http://localhost:${PORT}/`);
 });

--- a/server.js
+++ b/server.js
@@ -228,5 +228,9 @@ const server = http.createServer(async (req, res) => {
 const PORT = process.env.PORT || 3000;
 server.listen(PORT, '0.0.0.0', () => {
   console.log(`Server running at http://localhost:${PORT}/`);
-  console.log(`OpenRouter API key configured: ${!!API_KEY}`);
+  const hasKey = !!API_KEY;
+  console.log(`OpenRouter API key configured: ${hasKey}`);
+  if (!hasKey) {
+    console.warn('OPENROUTER_API_KEY is not set - real model queries will return an error payload');
+  }
 });

--- a/server/api-server.ts
+++ b/server/api-server.ts
@@ -10,9 +10,14 @@ import path from 'path';
 async function queryOpenRouter(prompt: string, modelId: string) {
   try {
     const API_KEY = process.env.OPENROUTER_API_KEY;
-    
+
     if (!API_KEY) {
-      throw new Error("OpenRouter API key is not configured");
+      return {
+        content: `OpenRouter API key not configured`,
+        title: `Error from ${modelId}`,
+        responseTime: 0,
+        error: 'OPENROUTER_API_KEY_MISSING'
+      };
     }
     
     const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
@@ -45,7 +50,8 @@ async function queryOpenRouter(prompt: string, modelId: string) {
     return {
       content: `Error getting response from ${modelId}: ${error instanceof Error ? error.message : 'Unknown error'}`,
       title: `Error from ${modelId}`,
-      responseTime: 0
+      responseTime: 0,
+      error: error instanceof Error ? error.message : String(error)
     };
   }
 }
@@ -227,7 +233,11 @@ export async function startStaticServer() {
   const server = createServer(app);
   server.listen(PORT, () => {
     console.log(`Static API server running on port ${PORT}`);
-    console.log(`OpenRouter API key configured: ${Boolean(process.env.OPENROUTER_API_KEY)}`);
+    const hasKey = Boolean(process.env.OPENROUTER_API_KEY);
+    console.log(`OpenRouter API key configured: ${hasKey}`);
+    if (!hasKey) {
+      console.warn('OPENROUTER_API_KEY is not set - real model queries will return an error payload');
+    }
   });
   
   return server;

--- a/server/index.ts
+++ b/server/index.ts
@@ -99,5 +99,10 @@ app.get(['/static', '/static-app', '/fallback'], (req, res) => {
     reusePort: true,
   }, () => {
     log(`serving on port ${port}`);
+    const hasKey = Boolean(process.env.OPENROUTER_API_KEY);
+    console.log(`OpenRouter API key configured: ${hasKey}`);
+    if (!hasKey) {
+      console.warn('OPENROUTER_API_KEY is not set - real model queries will return an error payload');
+    }
   });
 })();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -9,9 +9,14 @@ import { z } from "zod";
 async function queryOpenRouter(prompt: string, modelId: string) {
   try {
     const API_KEY = process.env.OPENROUTER_API_KEY;
-    
+
     if (!API_KEY) {
-      throw new Error("OpenRouter API key is not configured");
+      return {
+        content: `OpenRouter API key not configured`,
+        title: `Error from ${modelId}`,
+        responseTime: 0,
+        error: 'OPENROUTER_API_KEY_MISSING'
+      };
     }
     
     const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
@@ -44,7 +49,8 @@ async function queryOpenRouter(prompt: string, modelId: string) {
     return {
       content: `Error getting response from ${modelId}: ${error instanceof Error ? error.message : 'Unknown error'}`,
       title: `Error from ${modelId}`,
-      responseTime: 0
+      responseTime: 0,
+      error: error instanceof Error ? error.message : String(error)
     };
   }
 }

--- a/server/simple-index.ts
+++ b/server/simple-index.ts
@@ -14,9 +14,14 @@ app.use(express.json());
 async function queryOpenRouter(prompt: string, modelId: string) {
   try {
     const API_KEY = process.env.OPENROUTER_API_KEY;
-    
+
     if (!API_KEY) {
-      throw new Error("OpenRouter API key is not configured");
+      return {
+        content: `OpenRouter API key not configured`,
+        title: `Error from ${modelId}`,
+        responseTime: 0,
+        error: 'OPENROUTER_API_KEY_MISSING'
+      };
     }
     
     const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
@@ -49,7 +54,8 @@ async function queryOpenRouter(prompt: string, modelId: string) {
     return {
       content: `Error getting response from ${modelId}: ${error instanceof Error ? error.message : 'Unknown error'}`,
       title: `Error from ${modelId}`,
-      responseTime: 0
+      responseTime: 0,
+      error: error instanceof Error ? error.message : String(error)
     };
   }
 }
@@ -213,6 +219,11 @@ const server = createServer(app);
 
 server.listen(PORT, '0.0.0.0', () => {
   console.log(`Server running on port ${PORT}`);
+  const hasKey = Boolean(process.env.OPENROUTER_API_KEY);
+  console.log(`OpenRouter API key configured: ${hasKey}`);
+  if (!hasKey) {
+    console.warn('OPENROUTER_API_KEY is not set - real model queries will return an error payload');
+  }
 });
 
 // Start the Express server

--- a/server/static-app.ts
+++ b/server/static-app.ts
@@ -136,9 +136,14 @@ export function setupStaticApp(app: express.Express) {
 async function queryOpenRouter(prompt: string, modelId: string) {
   try {
     const API_KEY = process.env.OPENROUTER_API_KEY;
-    
+
     if (!API_KEY) {
-      throw new Error("OpenRouter API key is not configured");
+      return {
+        content: `OpenRouter API key not configured`,
+        title: `Error from ${modelId}`,
+        responseTime: 0,
+        error: 'OPENROUTER_API_KEY_MISSING'
+      };
     }
     
     const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
@@ -171,7 +176,8 @@ async function queryOpenRouter(prompt: string, modelId: string) {
     return {
       content: `Error getting response from ${modelId}: ${error instanceof Error ? error.message : 'Unknown error'}`,
       title: `Error from ${modelId}`,
-      responseTime: 0
+      responseTime: 0,
+      error: error instanceof Error ? error.message : String(error)
     };
   }
 }

--- a/simple-server.cjs
+++ b/simple-server.cjs
@@ -624,5 +624,9 @@ const server = http.createServer(async (req, res) => {
 const PORT = process.env.PORT || 3000;
 server.listen(PORT, '0.0.0.0', () => {
   console.log(`AI Search Engine running at http://localhost:${PORT}/`);
-  console.log(`OpenRouter API key configured: ${!!API_KEY}`);
+  const hasKey = !!API_KEY;
+  console.log(`OpenRouter API key configured: ${hasKey}`);
+  if (!hasKey) {
+    console.warn('OPENROUTER_API_KEY is not set - real model queries will return an error payload');
+  }
 });

--- a/standalone-server.mjs
+++ b/standalone-server.mjs
@@ -24,9 +24,14 @@ app.use('/static-assets', express.static(publicPath));
 async function queryOpenRouter(prompt, modelId) {
   try {
     const API_KEY = process.env.OPENROUTER_API_KEY;
-    
+
     if (!API_KEY) {
-      throw new Error("OpenRouter API key is not configured");
+      return {
+        content: `OpenRouter API key not configured`,
+        title: `Error from ${modelId}`,
+        responseTime: 0,
+        error: 'OPENROUTER_API_KEY_MISSING'
+      };
     }
     
     console.log(`Querying model ${modelId} for prompt: "${prompt.substring(0, 30)}..."`);
@@ -61,7 +66,8 @@ async function queryOpenRouter(prompt, modelId) {
     return {
       content: `Error getting response from ${modelId}: ${error.message || 'Unknown error'}`,
       title: `Error from ${modelId}`,
-      responseTime: 0
+      responseTime: 0,
+      error: error instanceof Error ? error.message : String(error)
     };
   }
 }
@@ -166,4 +172,9 @@ server.listen(PORT, '0.0.0.0', () => {
   console.log(`Server time: ${new Date().toISOString()}`);
   console.log(`Serving static files from: ${publicPath}`);
   console.log(`View app at: http://localhost:${PORT}/`);
+  const hasKey = Boolean(process.env.OPENROUTER_API_KEY);
+  console.log(`OpenRouter API key configured: ${hasKey}`);
+  if (!hasKey) {
+    console.warn('OPENROUTER_API_KEY is not set - real model queries will return an error payload');
+  }
 });


### PR DESCRIPTION
## Summary
- return structured error when `OPENROUTER_API_KEY` is missing
- warn at startup when the key isn't set
- document environment variable usage in README

## Testing
- `npm run check` *(fails: Could not find a declaration file for module './App.jsx' and other TS errors)*