### PR TITLE
Add basic unit tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "tsx --test tests/*.test.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -50,7 +50,7 @@ async function queryOpenRouter(prompt: string, modelId: string) {
 }
 
 // Helper to extract a title from response content
-function extractTitle(content: string = ""): string {
+export function extractTitle(content: string = ""): string {
   if (!content) return "AI Response";
   
   // Look for common title patterns in AI responses

--- a/tests/extractTitle.test.ts
+++ b/tests/extractTitle.test.ts
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractTitle } from '../server/routes';
+
+test('extract title from markdown heading', () => {
+  const res = extractTitle('# Heading\nContent here');
+  assert.equal(res, 'Heading');
+});
+
+test('extract title from Title: line', () => {
+  const res = extractTitle('Title: Sample\nMore text');
+  assert.equal(res, 'Sample');
+});
+
+test('fallback to first words', () => {
+  const res = extractTitle('This is a long response from the model with many words.');
+  assert.equal(res, 'This is a long response...');
+});
+
+test('empty content', () => {
+  const res = extractTitle('');
+  assert.equal(res, 'AI Response');
+});

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -1,0 +1,30 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { MemStorage } from '../server/storage';
+
+test('incrementModelClicks updates existing model', async () => {
+  const storage = new MemStorage();
+  const modelId = 'openai/gpt-4';
+  const statsBefore = await storage.getModelStats();
+  const original = statsBefore.find(s => s.modelId === modelId);
+  assert.ok(original);
+  const initial = original!.clickCount;
+  await storage.incrementModelClicks(modelId);
+  const statsAfter = await storage.getModelStats();
+  const updated = statsAfter.find(s => s.modelId === modelId);
+  assert.ok(updated);
+  assert.equal(updated!.clickCount, initial + 1);
+});
+
+test('incrementModelClicks creates new model stat', async () => {
+  const storage = new MemStorage();
+  const modelId = 'custom/new-model';
+  const statsBefore = await storage.getModelStats();
+  assert.ok(!statsBefore.some(s => s.modelId === modelId));
+  await storage.incrementModelClicks(modelId);
+  const statsAfter = await storage.getModelStats();
+  const created = statsAfter.find(s => s.modelId === modelId);
+  assert.ok(created);
+  assert.equal(created!.clickCount, 1);
+  assert.equal(created!.searchCount, 0);
+});


### PR DESCRIPTION
## Summary
- add simple Node-based test runner via `tsx`
- export `extractTitle` for testing
- add tests for storage analytics and extractTitle
- add GitHub Actions workflow running `npm test`

## Testing
- `npm test`