### PR TITLE
Update Cloudflare deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Future enhancements could include:
 
 1. Deploy the static frontend using **Cloudflare Pages**.
 
-   - Set the build command to `npm run build` and the output directory to `dist/public` so Vite places the production assets where Pages expects them.
+   - Set the build command to `npm run build` and the output directory to `dist/public`.
    - **Do not set** the `GITHUB_PAGES` environment variable when building for Cloudflare Pages. Leaving it enabled changes Vite's `base` path to `/VistAI/`, which will break asset and API URLs.
-   - Provide the Worker URL to the frontend by defining `API_BASE_URL` as an environment variable **or** adding a snippet before the bundled script. The static site uses this value to reach the Worker:
+   - When deploying Pages, provide the Worker URL by setting `API_BASE_URL` as an environment variable **or** adding a snippet before the bundled script:
 
      ```html
      <script>
@@ -94,7 +94,7 @@ Future enhancements could include:
 
     The application reads `window.API_BASE_URL` at runtime and prefixes all API requests with this value. If `GITHUB_PAGES` is enabled or `API_BASE_URL` points to the wrong location, the frontend will request assets and API routes from incorrect paths and you will see 404 errors.
 
-2. Deploy the API using **Cloudflare Workers** with `wrangler`. A sample `wrangler.toml` is included in this repository.
+2. Deploy the API using **Cloudflare Workers** with `wrangler`. The Worker's configuration is defined in `wrangler.toml`.
 
 3. Set your OpenRouter API key as a secret for the Worker. Run `wrangler secret put OPENROUTER_API_KEY` or add the variable under **Settings > Variables** in the Cloudflare dashboard so the Worker can authenticate with OpenRouter.
 


### PR DESCRIPTION
## Summary
- clarify Cloudflare Pages build output
- explain how to set `API_BASE_URL` when deploying Pages
- document that the Worker configuration lives in `wrangler.toml`
- note how to set the `OPENROUTER_API_KEY` secret

## Testing
- `npm test`