### PR TITLE
Fix environment config for worker deployment

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: vistAI
     steps:
       - uses: actions/checkout@v3
       - name: Publish worker


### PR DESCRIPTION
## Summary
- ensure `.github/workflows/deploy-worker.yml` uses the `vistAI` environment so it can access environment secrets

## Testing
- `npm run check`
- `npm test` *(fails: Missing script `test`)*