### PR TITLE
Add custom API base URL support

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -13,7 +13,12 @@ export async function apiRequest(
   data?: unknown | undefined,
   options?: { headers?: Record<string, string> },
 ): Promise<Response> {
-  const res = await fetch(url, {
+  const base = typeof window !== "undefined" && (window as any).API_BASE_URL;
+  const finalUrl = base && url.startsWith("/")
+    ? base.replace(/\/$/, "") + url
+    : url;
+
+  const res = await fetch(finalUrl, {
     method,
     headers: {
       ...(data ? { "Content-Type": "application/json" } : {}),


### PR DESCRIPTION
## Summary
- use `window.API_BASE_URL` if set to prefix API calls

## Testing
- `npm run check`