### PR TITLE
Add postbuild API_BASE_URL injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,13 @@ Future enhancements could include:
 
    - Set the build command to `npm run build` and the output directory to `dist/public`.
    - **Do not set** the `GITHUB_PAGES` environment variable when building for Cloudflare Pages. Leaving it enabled changes Vite's `base` path to `/VistAI/`, which will break asset and API URLs.
-   - When deploying Pages, provide the Worker URL by setting `API_BASE_URL` as an environment variable **or** adding a snippet before the bundled script:
+   - Provide the Worker URL via the `API_BASE_URL` environment variable. When this variable is set the build script automatically injects the following snippet into `dist/public/index.html`:
 
      ```html
-     <script>
-       window.API_BASE_URL = "https://vistai-worker.yourdomain.workers.dev";
-     </script>
+     <script>window.API_BASE_URL = "https://vistai-worker.yourdomain.workers.dev";</script>
      ```
 
-    The application reads `window.API_BASE_URL` at runtime and prefixes all API requests with this value. If `GITHUB_PAGES` is enabled or `API_BASE_URL` points to the wrong location, the frontend will request assets and API routes from incorrect paths and you will see 404 errors.
+     The application reads `window.API_BASE_URL` at runtime and prefixes all API requests with this value. If `GITHUB_PAGES` is enabled or `API_BASE_URL` points to the wrong location, the frontend will request assets and API routes from incorrect paths and you will see 404 errors.
 
 2. Deploy the API using **Cloudflare Workers** with `wrangler`. The Worker's configuration is defined in `wrangler.toml`.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && node scripts/inject-api-base-url.js",
     "check": "tsc",
     "test": "npm run check"
   },

--- a/scripts/inject-api-base-url.js
+++ b/scripts/inject-api-base-url.js
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const apiBaseUrl = process.env.API_BASE_URL;
+if (!apiBaseUrl) {
+  process.exit(0);
+}
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const indexPath = path.resolve(__dirname, '..', 'dist', 'public', 'index.html');
+
+if (!fs.existsSync(indexPath)) {
+  console.error(`index.html not found at ${indexPath}`);
+  process.exit(1);
+}
+
+const html = fs.readFileSync(indexPath, 'utf8');
+const snippet = `<script>window.API_BASE_URL = "${apiBaseUrl}";</script>`;
+
+let output;
+if (html.includes('</head>')) {
+  output = html.replace('</head>', `  ${snippet}\n</head>`);
+} else {
+  output = `${snippet}\n${html}`;
+}
+
+fs.writeFileSync(indexPath, output);
+console.log('Injected API_BASE_URL snippet into index.html');


### PR DESCRIPTION
## Summary
- add a script that injects the API base URL into `dist/public/index.html`
- run the script automatically after `vite build`
- document how the Worker URL is provided for Cloudflare Pages deployments

## Testing
- `npm run check`
- `API_BASE_URL=https://example.com npm run build`