### PR TITLE
Improve origin check for apiRequest

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -46,19 +46,14 @@ export const getQueryFn: <T>(options: {
 }) => QueryFunction<T> =
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
-    const base =
-      typeof window !== "undefined" && (window as any).API_BASE_URL;
     const url = queryKey[0] as string;
-    const finalUrl = base && url.startsWith("/")
-      ? base.replace(/\/$/, "") + url
-      : url;
 
-    const useCredentials =
-      !base || finalUrl.startsWith(window.location.origin);
-
-    const res = await fetch(finalUrl, {
-      credentials: useCredentials ? "include" : "omit",
-    });
+    const res = await apiRequest(
+      "GET",
+      url,
+      undefined,
+      { skipErrorHandling: true },
+    );
 
     if (unauthorizedBehavior === "returnNull" && res.status === 401) {
       return null;


### PR DESCRIPTION
## Summary
- reuse `apiRequest` in `getQueryFn` to consolidate same-origin credential logic

## Testing
- `npm test`