### PR TITLE
Update credentials logic for cross-origin requests

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -21,8 +21,8 @@ export async function apiRequest(
     ? base.replace(/\/$/, "") + url
     : url;
 
-  const useCredentials =
-    !base || finalUrl.startsWith(window.location.origin);
+  const finalOrigin = new URL(finalUrl, window.location.href).origin;
+  const useCredentials = finalOrigin === window.location.origin;
 
   const res = await fetch(finalUrl, {
     method,


### PR DESCRIPTION
## Summary
- determine the origin of the final request URL in `apiRequest`
- include credentials only for same-origin requests

## Testing
- `npm run check`