### PR TITLE
Fix API_BASE_URL injection

### DIFF
--- a/scripts/inject-api-base-url.js
+++ b/scripts/inject-api-base-url.js
@@ -16,7 +16,7 @@ if (!fs.existsSync(indexPath)) {
 }
 
 const html = fs.readFileSync(indexPath, 'utf8');
-const snippet = '<script>window.API_BASE_URL = "<%= process.env.API_BASE_URL %>";</script>';
+const snippet = `<script>window.API_BASE_URL = "${apiBaseUrl}";</script>`;
 
 let output;
 if (html.includes('</head>')) {
@@ -26,4 +26,4 @@ if (html.includes('</head>')) {
 }
 
 fs.writeFileSync(indexPath, output);
-console.log('Appended API_BASE_URL placeholder snippet into index.html');
+console.log('Inserted API_BASE_URL snippet into index.html');


### PR DESCRIPTION
## Summary
- fix snippet in injection script to write the real `API_BASE_URL`
- rebuild frontend with `API_BASE_URL=https://vistai-api.example.workers.dev`

## Testing
- `npm test`
- `API_BASE_URL=https://vistai-api.example.workers.dev npm run build`