### PR TITLE
Fix search ID consistency

### DIFF
--- a/worker/worker.js
+++ b/worker/worker.js
@@ -112,6 +112,7 @@ function createStorage() {
   let searchId = 1;
   let resultId = 1;
   let clickId = 1;
+  let modelStatId = 1;
   const searches = new Map();
   const results = new Map();
   const modelStats = new Map();
@@ -123,7 +124,7 @@ function createStorage() {
     'mistralai/mistral-7b-instruct',
   ];
   defaultModels.forEach((m) => {
-    modelStats.set(m, { id: searchId++, modelId: m, clickCount: 0, searchCount: 0, updatedAt: new Date() });
+    modelStats.set(m, { id: modelStatId++, modelId: m, clickCount: 0, searchCount: 0, updatedAt: new Date() });
   });
 
   return {


### PR DESCRIPTION
## Summary
- keep search IDs consistent by using a separate counter for model statistics

## Testing
- `npm run check`
