### PR TITLE
Move worker to D1 storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ Open `dist/public/index.html` in your browser to test locally.
 
 Set `OPENROUTER_API_KEY` as a secret when deploying the Cloudflare worker.
 
+## D1 Database
+
+Search analytics are persisted in a Cloudflare D1 database. The worker expects a binding named `DB` which is configured in `wrangler.toml`. Replace the sample `database_id` with the ID of your database from the Cloudflare dashboard and apply the migrations:
+
+```bash
+# create the database if you haven't already
+wrangler d1 create vistai
+wrangler d1 migrations apply vistai
+```
+
+The schema for the initial migration lives in `worker/migrations/0001_init.sql`.
+
 ## Project Structure
 
 - `client/`: React frontend components and pages

--- a/worker/db.js
+++ b/worker/db.js
@@ -1,0 +1,88 @@
+export async function createSearch(db, { query }) {
+  const now = new Date().toISOString();
+  const { results } = await db
+    .prepare(
+      'INSERT INTO searches (query, created_at) VALUES (?, ?) RETURNING id, query, created_at'
+    )
+    .bind(query, now)
+    .all();
+  return results[0];
+}
+
+export async function createResult(db, { searchId, modelId, content, title, responseTime }) {
+  const now = new Date().toISOString();
+  const { results } = await db
+    .prepare(
+      'INSERT INTO results (search_id, model_id, content, title, response_time, created_at) VALUES (?,?,?,?,?,?) RETURNING id, search_id as searchId, model_id as modelId, content, title, response_time as responseTime, created_at as createdAt'
+    )
+    .bind(searchId, modelId, content, title, responseTime, now)
+    .all();
+  return results[0];
+}
+
+export async function trackClick(db, { resultId }) {
+  const now = new Date().toISOString();
+  const { results } = await db
+    .prepare(
+      'INSERT INTO clicks (result_id, created_at) VALUES (?, ?) RETURNING id, result_id as resultId, created_at as createdAt'
+    )
+    .bind(resultId, now)
+    .all();
+  await db
+    .prepare(
+      'UPDATE model_stats SET click_count = click_count + 1, updated_at = ? WHERE model_id = (SELECT model_id FROM results WHERE id = ?)' 
+    )
+    .bind(now, resultId)
+    .run();
+  return results[0];
+}
+
+export async function incrementModelSearches(db, modelId) {
+  const now = new Date().toISOString();
+  await db
+    .prepare(
+      'INSERT INTO model_stats (model_id, click_count, search_count, updated_at) VALUES (?,0,0,?) ON CONFLICT(model_id) DO NOTHING'
+    )
+    .bind(modelId, now)
+    .run();
+  await db
+    .prepare(
+      'UPDATE model_stats SET search_count = search_count + 1, updated_at = ? WHERE model_id = ?'
+    )
+    .bind(now, modelId)
+    .run();
+}
+
+export async function getModelStats(db) {
+  const { results } = await db
+    .prepare(
+      'SELECT model_id as modelId, click_count as clickCount, search_count as searchCount, updated_at as updatedAt FROM model_stats'
+    )
+    .all();
+  return results;
+}
+
+export async function getModelStatsWithPercent(db) {
+  const stats = await getModelStats(db);
+  const totalClicks = stats.reduce((sum, s) => sum + (s.clickCount || 0), 0);
+  return stats.map((s) => ({
+    ...s,
+    percentage: totalClicks > 0 ? Math.round((s.clickCount / totalClicks) * 100) : 0,
+    displayName: s.modelId.split('/').pop(),
+  }));
+}
+
+export async function getTopModelsWithPercent(db, limit) {
+  const { results } = await db
+    .prepare(
+      'SELECT model_id as modelId, click_count as clickCount, search_count as searchCount, updated_at as updatedAt FROM model_stats ORDER BY click_count DESC LIMIT ?'
+    )
+    .bind(limit)
+    .all();
+  const totalClicks = results.reduce((sum, s) => sum + (s.clickCount || 0), 0);
+  return results.map((s) => ({
+    ...s,
+    percentage: totalClicks > 0 ? Math.round((s.clickCount / totalClicks) * 100) : 0,
+    displayName: s.modelId.split('/').pop(),
+  }));
+}

--- a/worker/migrations/0001_init.sql
+++ b/worker/migrations/0001_init.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS searches (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  query TEXT NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS results (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  search_id INTEGER NOT NULL,
+  model_id TEXT NOT NULL,
+  content TEXT NOT NULL,
+  title TEXT NOT NULL,
+  response_time INTEGER,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS clicks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  result_id INTEGER NOT NULL,
+  created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS model_stats (
+  model_id TEXT PRIMARY KEY,
+  click_count INTEGER DEFAULT 0,
+  search_count INTEGER DEFAULT 0,
+  updated_at TEXT NOT NULL
+);

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,3 +8,9 @@ compatibility_date = "2025-05-26"
 
 [observability]
 enabled = true
+
+[[d1_databases]]
+binding = "DB"
+database_name = "vistai"
+# Replace with your D1 database ID
+database_id = "11111111-1111-1111-1111-111111111111"


### PR DESCRIPTION
## Summary
- store search analytics in Cloudflare D1 instead of in-memory maps
- add helper module `worker/db.js`
- update API handlers to use D1
- configure `wrangler.toml` with a D1 binding
- document D1 setup and include migration

## Testing
- `npm test`
