### PR TITLE
Fix synchronous search result handling

### DIFF
--- a/worker/worker.js
+++ b/worker/worker.js
@@ -63,17 +63,23 @@ export default {
 
         const results = [];
         for (const modelId of models) {
-          const modelResponse = await queryOpenRouter(query, modelId, env.OPENROUTER_API_KEY);
-
-          const result = env.storage.createResult({
+          const modelResponse = await queryOpenRouter(
+            query,
+            modelId,
+            env.OPENROUTER_API_KEY,
+          );
+          const result = await createResult(env.DB, {
             searchId: search.id,
             modelId,
             content: modelResponse.content,
             title: modelResponse.title,
             responseTime: modelResponse.responseTime,
           });
-          return { ...result, modelName: modelId.split('/').pop() };
-        });
+          results.push({
+            ...result,
+            modelName: modelId.split('/').pop(),
+          });
+        }
 
         return jsonResponse({
           search,


### PR DESCRIPTION
## Summary
- fix result generation loop in `/api/search`
- ensure generated results use `createResult` and are included in JSON response

## Testing
- `npm test`
