### PR TITLE
Add env checks and status indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Future enhancements could include:
 
 3. Set your OpenRouter API key as a secret for the Worker. Run `wrangler secret put OPENROUTER_API_KEY` or add the variable under **Settings > Variables** in the Cloudflare dashboard so the Worker can authenticate with OpenRouter.
 
+   The Worker checks that both this API key and the `DB` database binding are configured before handling any request. If either is missing it responds with HTTP 500 and a descriptive error.
+
 4. The repository includes a GitHub Actions workflow that automatically runs `wrangler deploy` whenever changes to the Worker are pushed to the `main` branch. Configure `CF_API_TOKEN` and `CF_ACCOUNT_ID` secrets in your repository settings to enable this automation.
 
 Once both are deployed the site will automatically call the Worker endpoints via the configured base URL.

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,10 +1,18 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { extractTitle } from '../worker/worker.js';
+import worker, { extractTitle } from '../worker/worker.js';
 
 
 test('extractTitle pulls heading or first line', () => {
   assert.strictEqual(extractTitle('# Hello world'), 'Hello world');
   assert.strictEqual(extractTitle('Title: Example\nMore'), 'Example');
   assert.strictEqual(extractTitle('Just first line\nSecond line'), 'Just first line');
+});
+
+test('missing DB returns descriptive error', async () => {
+  const req = new Request('http://localhost/api/status');
+  const res = await worker.fetch(req, { OPENROUTER_API_KEY: 'key' });
+  assert.strictEqual(res.status, 500);
+  const data = await res.json();
+  assert.strictEqual(data.message, 'Database binding DB is not configured');
 });

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -28,6 +28,8 @@ paths:
                     type: string
                   apiKey:
                     type: boolean
+                  db:
+                    type: boolean
                   time:
                     type: string
   /api/search:
@@ -173,11 +175,19 @@ export default {
       });
     }
 
+    if (!env.DB) {
+      return jsonResponse({ message: 'Database binding DB is not configured' }, headers, 500);
+    }
+    if (!env.OPENROUTER_API_KEY) {
+      return jsonResponse({ message: 'OPENROUTER_API_KEY is missing' }, headers, 500);
+    }
+
     try {
       if (pathname === '/api/status' && request.method === 'GET') {
         return jsonResponse({
           status: 'ok',
           apiKey: Boolean(env.OPENROUTER_API_KEY),
+          db: Boolean(env.DB),
           time: new Date().toISOString(),
         }, headers);
       }


### PR DESCRIPTION
## Summary
- verify `DB` and `OPENROUTER_API_KEY` bindings exist before handling any API route
- expose the database status from `/api/status`
- document new configuration check
- test descriptive error when DB binding is missing

## Testing
- `npm test`