### PR TITLE
Add search-based location hook

### DIFF
--- a/client/src/hooks/use-full-location.ts
+++ b/client/src/hooks/use-full-location.ts
@@ -1,0 +1,17 @@
+import { navigate, useLocationProperty } from "wouter/use-browser-location";
+import type { BaseLocationHook, BaseSearchHook } from "wouter";
+
+/**
+ * Custom location hook that updates when either pathname or search
+ * changes. It returns the full location string including the query
+ * string and can be used as the Router `hook`.
+ */
+export const useFullLocation: BaseLocationHook = () => {
+  const location = useLocationProperty(
+    () => window.location.pathname + window.location.search,
+  );
+  return [location, navigate];
+};
+
+export const useLocationSearch: BaseSearchHook = () =>
+  useLocationProperty(() => window.location.search);

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from "react-dom/client";
 import { Router } from "wouter";
+import { useLocationSearch } from "./hooks/use-full-location";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "./lib/queryClient";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -10,7 +11,7 @@ import "./index.css";
 createRoot(document.getElementById("root")!).render(
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
-      <Router>
+      <Router searchHook={useLocationSearch}>
         <App />
       </Router>
       <Toaster />

--- a/client/src/pages/SearchResults.tsx
+++ b/client/src/pages/SearchResults.tsx
@@ -6,10 +6,12 @@ import ModelFilterPills from "@/components/ModelFilterPills";
 import LoadingSkeleton from "@/components/LoadingSkeleton";
 import SearchBar from "@/components/SearchBar";
 import { useLocation } from "wouter";
+import { useLocationSearch } from "@/hooks/use-full-location";
 
 export default function SearchResults() {
-  const [location, navigate] = useLocation();
-  const params = new URLSearchParams(location.split("?")[1] || "");
+  const [, navigate] = useLocation();
+  const searchString = useLocationSearch();
+  const params = new URLSearchParams(searchString);
   const query = params.get("q") || "";
   const [selectedModel, setSelectedModel] = useState<string | null>(null);
   const [results, setResults] = useState<ModelResponse[]>([]);


### PR DESCRIPTION
## Summary
- track `location.search` with a custom hook
- wire `<Router>` to use the new search hook
- pull query string from the custom hook in `SearchResults`

## Testing
- `npm test`