### PR TITLE
Add type check step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,4 +14,5 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
+      - run: npm run check
       - run: npm test

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ The schema for the initial migration lives in `worker/migrations/0001_init.sql`.
 - `shared/`: Shared types and schemas
 - `worker/`: Cloudflare Worker implementation
 
+## Testing and Type Checking
+
+Install dependencies including development packages before running the
+test suite and TypeScript compilation:
+
+```bash
+npm ci
+npm test
+npm run check
+```
+
 ## API Documentation
 
 Interactive API docs are available when the worker is running. Visit


### PR DESCRIPTION
## Summary
- add `npm run check` to CI workflow
- document how to install dev deps before running tests

## Testing
- `npm test`
- `npm run check`
