### PR TITLE
Add summary snippets to model results

### DIFF
--- a/client/src/components/ResultCard.tsx
+++ b/client/src/components/ResultCard.tsx
@@ -28,7 +28,7 @@ export default function ResultCard({ result }: ResultCardProps) {
   const [copied, setCopied] = useState(false);
   const [feedback, setFeedback] = useState<"liked" | "disliked" | null>(null);
   const [open, setOpen] = useState(false);
-  const preview = result.content.split(/\n/)[0];
+  const preview = result.snippet || result.content.split(/\n/)[0];
   const truncated = preview.length > 120 ? preview.slice(0, 120) + "..." : preview;
 
   const handleOpenChange = (value: boolean) => {

--- a/client/src/lib/openrouter.ts
+++ b/client/src/lib/openrouter.ts
@@ -5,6 +5,7 @@ export interface ModelResponse {
   id: number;
   searchId: number;
   modelId: string;
+  snippet?: string;
   content: string;
   title?: string;
   responseTime?: number;

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,12 +1,17 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import worker, { extractTitle } from '../worker/worker.js';
+import worker, { extractTitle, extractSnippet } from '../worker/worker.js';
 
 
 test('extractTitle pulls heading or first line', () => {
   assert.strictEqual(extractTitle('# Hello world'), 'Hello world');
   assert.strictEqual(extractTitle('Title: Example\nMore'), 'Example');
   assert.strictEqual(extractTitle('Just first line\nSecond line'), 'Just first line');
+});
+
+test('extractSnippet parses summary tag', () => {
+  const input = '<summary>Brief</summary>Full answer here';
+  assert.deepStrictEqual(extractSnippet(input), { snippet: 'Brief', body: 'Full answer here' });
 });
 
 test('missing DB returns descriptive error', async () => {


### PR DESCRIPTION
## Summary
- include a system message asking models for a `<summary>` snippet
- parse the snippet on the server and expose it via the API
- display the snippet in `ResultCard` previews
- document snippet field in the OpenAPI spec
- extend TypeScript types and tests for snippet parsing

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm test` *(fails: tsx not found)*