### PR TITLE
Ensure dynamic fallback models used when API fails

### DIFF
--- a/tests/model-selection.test.ts
+++ b/tests/model-selection.test.ts
@@ -1,13 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import worker from '../worker/worker.js';
+import worker, { FALLBACK_MODELS } from '../worker/worker.js';
 import { FakeD1Database } from './fake-db.js';
 
 test('uses DB top models when OpenRouter fails', async () => {
   const now = new Date().toISOString();
   const db = new FakeD1Database({
-    'model/A': { clickCount: 5, searchCount: 10, updatedAt: now },
-    'model/B': { clickCount: 3, searchCount: 8, updatedAt: now },
+    [FALLBACK_MODELS[0]]: { clickCount: 5, searchCount: 10, updatedAt: now },
+    [FALLBACK_MODELS[1]]: { clickCount: 3, searchCount: 8, updatedAt: now },
   });
 
   const originalFetch = global.fetch;
@@ -36,6 +36,9 @@ test('uses DB top models when OpenRouter fails', async () => {
 
   const res = await worker.fetch(req, { DB: db, OPENROUTER_API_KEY: 'key' });
   const data = await res.json();
-  assert.deepStrictEqual(data.results.map((r: any) => r.modelId), ['model/A', 'model/B']);
+  assert.deepStrictEqual(
+    data.results.map((r: any) => r.modelId),
+    [FALLBACK_MODELS[0], FALLBACK_MODELS[1]]
+  );
   global.fetch = originalFetch;
 });

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -8,6 +8,17 @@ import {
   getTopModelsWithPercent,
 } from './db.js';
 
+/**
+ * Fallback model list used when dynamic fetch fails.
+ */
+export const FALLBACK_MODELS = [
+  'google/gemini-2.0-flash-001',
+  'openai/gpt-4o-mini',
+  'anthropic/claude-3.7-sonnet',
+  'google/gemini-2.5-pro-preview',
+  'deepseek/deepseek-chat-v3-0324:free',
+];
+
 const openapiSpec = `openapi: 3.0.0
 info:
   title: VistAI API
@@ -260,19 +271,13 @@ export default {
           console.warn('Failed to fetch models from OpenRouter', err);
           try {
             const stats = await getTopModelsWithPercent(env.DB, 4);
-            models = stats.map((s) => s.modelId);
+            const filtered = stats
+              .map((s) => s.modelId)
+              .filter((m) => FALLBACK_MODELS.includes(m));
+            models = filtered.length > 0 ? filtered : [...FALLBACK_MODELS];
           } catch (dbErr) {
             console.warn('Failed to fetch models from DB', dbErr);
-            models = [];
-          }
-          if (!models || models.length === 0) {
-            models = [
-              'google/gemini-2.0-flash-001',
-              'openai/gpt-4o-mini',
-              'anthropic/claude-3.7-sonnet',
-              'google/gemini-2.5-pro-preview',
-              'deepseek/deepseek-chat-v3-0324:free',
-            ];
+            models = [...FALLBACK_MODELS];
           }
         }
 


### PR DESCRIPTION
## Summary
- export `FALLBACK_MODELS` from worker
- prefer new fallback model list if OpenRouter or DB fetch fails
- update model selection test to use exported fallback list

## Testing
- `npm test`
- `npm run check`
