### PR TITLE
Add query suggestions endpoint and client updates

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -83,19 +83,62 @@ export function getModelInfo(modelId: string) {
   };
 }
 
-/** Example search suggestions used on the home page. */
-export const searchSuggestions = [
+/** Default suggestions used when no history or API data is available. */
+const fallbackSuggestions = [
   "Explain quantum computing",
   "Create a workout plan",
   "Compare React vs Vue",
   "Summarize climate change solutions",
-  "Recipe for vegan chocolate cake"
+  "Recipe for vegan chocolate cake",
 ];
 
+/** Retrieve recent search history from localStorage. */
+export function getSearchHistory(limit = 5): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem("searchHistory");
+    const arr = JSON.parse(raw || "[]");
+    return Array.isArray(arr) ? arr.slice(-limit).reverse() : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Store a query in local search history. */
+export function addToSearchHistory(query: string) {
+  if (typeof window === "undefined") return;
+  try {
+    const arr = getSearchHistory(20);
+    const newArr = [query, ...arr.filter((q) => q !== query)].slice(0, 20);
+    window.localStorage.setItem("searchHistory", JSON.stringify(newArr.reverse()));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+/** Fetch popular queries from the backend API. */
+export async function fetchPopularQueries(limit = 5): Promise<string[]> {
+  try {
+    const res = await fetch(`/api/popular-queries?limit=${limit}`);
+    if (!res.ok) throw new Error("fail");
+    const data = await res.json();
+    return data.map((d: { query: string }) => d.query);
+  } catch {
+    return [];
+  }
+}
+
 /**
- * Select a random subset of suggestions.
+ * Select a random subset of suggestions using history or API data.
  */
-export function getRandomSuggestions(count: number = 3): string[] {
-  const shuffled = [...searchSuggestions].sort(() => 0.5 - Math.random());
+export async function getRandomSuggestions(count: number = 3): Promise<string[]> {
+  const history = getSearchHistory(count);
+  let pool: string[] = history;
+  if (pool.length < count) {
+    const fromApi = await fetchPopularQueries(count * 2);
+    pool = [...history, ...fromApi];
+  }
+  if (pool.length === 0) pool = [...fallbackSuggestions];
+  const shuffled = [...new Set(pool)].sort(() => 0.5 - Math.random());
   return shuffled.slice(0, count);
 }

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { getRandomSuggestions } from "@/lib/utils";
 import SearchBar from "@/components/SearchBar";
 import { Link, useLocation } from "wouter";
@@ -8,7 +8,11 @@ import { Link, useLocation } from "wouter";
  */
 export default function Home() {
   const [, navigate] = useLocation();
-  const [suggestions] = useState(() => getRandomSuggestions(3));
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+
+  useEffect(() => {
+    getRandomSuggestions(3).then(setSuggestions);
+  }, []);
 
   const handleSearch = (query: string) => {
     navigate(`/search?q=${encodeURIComponent(query)}`);

--- a/client/src/pages/SearchResults.tsx
+++ b/client/src/pages/SearchResults.tsx
@@ -43,7 +43,7 @@ export default function SearchResults() {
       } else if (evt.type === "done") {
         setTotalTime(evt.data.totalTime);
         setIsLoading(false);
-        saveQueryToHistory(query);
+        addQueryToHistory(query);
       } else if (evt.type === "error") {
         setError(new Error(evt.data?.message || "Stream error"));
         setIsLoading(false);

--- a/client/src/pages/SearchResults.tsx
+++ b/client/src/pages/SearchResults.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { searchAIStream, ModelResponse, SearchStreamEvent } from "@/lib/openrouter";
-import { formatSearchTime } from "@/lib/utils";
+import { formatSearchTime, addToSearchHistory } from "@/lib/utils";
 import ResultCard from "@/components/ResultCard";
 import ModelFilterPills from "@/components/ModelFilterPills";
 import LoadingSkeleton from "@/components/LoadingSkeleton";
@@ -25,6 +25,8 @@ export default function SearchResults() {
 
   useEffect(() => {
     if (!query) return;
+
+    addToSearchHistory(query);
 
     setSelectedModel(null);
     setResults([]);

--- a/client/src/pages/SearchResults.tsx
+++ b/client/src/pages/SearchResults.tsx
@@ -43,7 +43,7 @@ export default function SearchResults() {
       } else if (evt.type === "done") {
         setTotalTime(evt.data.totalTime);
         setIsLoading(false);
-        addQueryToHistory(query);
+        addToSearchHistory(query);
       } else if (evt.type === "error") {
         setError(new Error(evt.data?.message || "Stream error"));
         setIsLoading(false);

--- a/tests/fake-db.ts
+++ b/tests/fake-db.ts
@@ -52,6 +52,26 @@ export class FakeD1Database {
             .slice(0, limit);
           return { results: arr };
         }
+        if (q.startsWith('SELECT query, COUNT(*) as count FROM searches')) {
+          const limit = a[0];
+          const counts: Record<string, number> = {};
+          for (const s of db.searches) {
+            counts[s.query] = (counts[s.query] || 0) + 1;
+          }
+          const arr = Object.entries(counts)
+            .map(([query, count]) => ({ query, count }))
+            .sort((a, b) => b.count - a.count)
+            .slice(0, limit);
+          return { results: arr };
+        }
+        if (q.startsWith('SELECT query, created_at as createdAt FROM searches')) {
+          const limit = a[0];
+          const arr = [...db.searches]
+            .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+            .slice(0, limit)
+            .map((s) => ({ query: s.query, createdAt: s.createdAt }));
+          return { results: arr };
+        }
         if (q.startsWith('SELECT model_id as modelId')) {
           const arr = Object.entries(db.modelStats)
             .map(([modelId, s]) => ({ modelId, clickCount: s.clickCount, searchCount: s.searchCount, updatedAt: s.updatedAt }));

--- a/tests/query-endpoints.test.ts
+++ b/tests/query-endpoints.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import worker from '../worker/worker.js';
+import { FakeD1Database } from './fake-db.js';
+import { createSearch } from '../worker/db.js';
+
+/** Verify popular and recent query endpoints. */
+test('popular and recent queries', async () => {
+  const db = new FakeD1Database();
+  await createSearch(db as any, { query: 'foo' });
+  await createSearch(db as any, { query: 'bar' });
+  await createSearch(db as any, { query: 'foo' });
+
+  const popularReq = new Request('http://localhost/api/popular-queries?limit=2');
+  const popularRes = await worker.fetch(popularReq, { DB: db, OPENROUTER_API_KEY: 'k' });
+  assert.strictEqual(popularRes.status, 200);
+  const popular = await popularRes.json();
+  assert.deepStrictEqual(popular, [
+    { query: 'foo', count: 2 },
+    { query: 'bar', count: 1 },
+  ]);
+
+  const recentReq = new Request('http://localhost/api/recent-queries?limit=2');
+  const recentRes = await worker.fetch(recentReq, { DB: db, OPENROUTER_API_KEY: 'k' });
+  assert.strictEqual(recentRes.status, 200);
+  const recent = await recentRes.json();
+  const queries = recent.map((r: any) => r.query);
+  assert.ok(queries.includes('foo') && queries.includes('bar'));
+});

--- a/worker/db.js
+++ b/worker/db.js
@@ -135,3 +135,29 @@ export async function getTopModelsWithPercent(db, limit) {
     displayName: s.modelId.split('/').pop(),
   }));
 }
+
+/**
+ * Get the most frequently searched queries.
+ */
+export async function getPopularQueries(db, limit) {
+  const { results } = await db
+    .prepare(
+      'SELECT query, COUNT(*) as count FROM searches GROUP BY query ORDER BY count DESC LIMIT ?'
+    )
+    .bind(limit)
+    .all();
+  return results.map((r) => ({ query: r.query, count: r.count }));
+}
+
+/**
+ * Get the most recent search queries.
+ */
+export async function getRecentQueries(db, limit) {
+  const { results } = await db
+    .prepare(
+      'SELECT query, created_at as createdAt FROM searches ORDER BY created_at DESC LIMIT ?'
+    )
+    .bind(limit)
+    .all();
+  return results;
+}

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -5,6 +5,8 @@ import {
   incrementModelSearches,
   getModelStatsWithPercent,
   getTopModelsWithPercent,
+  getPopularQueries,
+  getRecentQueries,
   createUser,
   findUser,
   hashPassword,
@@ -248,6 +250,52 @@ paths:
                       type: integer
                     displayName:
                       type: string
+  /api/popular-queries:
+    get:
+      summary: Get most searched queries
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+          required: false
+      responses:
+        '200':
+          description: Popular queries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    query:
+                      type: string
+                    count:
+                      type: integer
+  /api/recent-queries:
+    get:
+      summary: Get recent search queries
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+          required: false
+      responses:
+        '200':
+          description: Recent queries
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    query:
+                      type: string
+                    createdAt:
+                      type: string
 `;
 
 const swaggerHtml = `<!DOCTYPE html>
@@ -466,6 +514,18 @@ export default {
         const limit = parseInt(searchParams.get('limit') || '5', 10);
         const stats = await getTopModelsWithPercent(env.DB, limit);
         return jsonResponse(stats, headers);
+      }
+
+      if (pathname === '/api/popular-queries' && request.method === 'GET') {
+        const limit = parseInt(searchParams.get('limit') || '5', 10);
+        const queries = await getPopularQueries(env.DB, limit);
+        return jsonResponse(queries, headers);
+      }
+
+      if (pathname === '/api/recent-queries' && request.method === 'GET') {
+        const limit = parseInt(searchParams.get('limit') || '5', 10);
+        const queries = await getRecentQueries(env.DB, limit);
+        return jsonResponse(queries, headers);
       }
 
       return new Response('Not Found', { status: 404, headers });


### PR DESCRIPTION
## Summary
- expose `/api/popular-queries` and `/api/recent-queries` in the worker
- support fetching popular/recent queries in the DB layer
- extend fake database for new queries
- show dynamic suggestions on the home page
- store search history locally and use it for suggestions
- add tests for new endpoints

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_683a07ecad888320bf3643d59978c3e2