### PR TITLE
Add settings page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import Footer from "@/components/Footer";
 import Home from "@/pages/Home";
 import SearchResults from "@/pages/SearchResults";
 import Dashboard from "@/pages/Dashboard";
+import Settings from "@/pages/Settings";
 import Login from "@/pages/Login";
 import Register from "@/pages/Register";
 import NotFound from "@/pages/not-found";
@@ -21,6 +22,7 @@ export default function App() {
           <Route path="/" component={Home} />
           <Route path="/search" component={SearchResults} />
           <Route path="/dashboard" component={Dashboard} />
+          <Route path="/settings" component={Settings} />
           <Route path="/login" component={Login} />
           <Route path="/register" component={Register} />
           <Route component={NotFound} />

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -44,7 +44,7 @@ export default function Home() {
           <p className="text-muted-foreground text-sm">
             Powered by <a href="https://openrouter.ai" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">OpenRouter</a> •
             <Link href="/dashboard" className="text-muted-foreground hover:text-foreground ml-1">Dashboard</Link> •
-            <button className="text-muted-foreground hover:text-foreground ml-1">Settings</button>
+            <Link href="/settings" className="text-muted-foreground hover:text-foreground ml-1">Settings</Link>
           </p>
         </div>
       </div>

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+
+/**
+ * Settings page for managing user preferences.
+ */
+export default function Settings() {
+  const [darkMode, setDarkMode] = useState(false);
+
+  // Initialize theme from localStorage
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem("theme");
+    const prefersDark =
+      stored === "dark" || (!stored && window.matchMedia("(prefers-color-scheme: dark)").matches);
+    setDarkMode(prefersDark);
+  }, []);
+
+  // Apply theme when darkMode changes
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const root = document.documentElement;
+    if (darkMode) {
+      root.classList.add("dark");
+      window.localStorage.setItem("theme", "dark");
+    } else {
+      root.classList.remove("dark");
+      window.localStorage.setItem("theme", "light");
+    }
+  }, [darkMode]);
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col">
+        <h1 className="text-3xl font-bold tracking-tight">Settings</h1>
+        <p className="text-muted-foreground">Manage your preferences</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Appearance</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between">
+            <span className="text-sm">Dark Mode</span>
+            <Switch checked={darkMode} onCheckedChange={setDarkMode} />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add settings page with theme toggle
- register settings route
- link to settings from home page

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_683a07f1a5e48320a595812bb5409641