### PR TITLE
Add query history dropdown

### DIFF
--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -1,5 +1,5 @@
 import { useState, FormEvent, useRef, useEffect } from "react";
-import { cn } from "@/lib/utils";
+import { cn, getQueryHistory, clearQueryHistory } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 
@@ -14,6 +14,8 @@ interface SearchBarProps {
  */
 export default function SearchBar({ initialQuery = "", compact = false, onSearch }: SearchBarProps) {
   const [query, setQuery] = useState(initialQuery);
+  const [history, setHistory] = useState<string[]>([]);
+  const [showHistory, setShowHistory] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -21,6 +23,15 @@ export default function SearchBar({ initialQuery = "", compact = false, onSearch
       inputRef.current.focus();
     }
   }, [compact]);
+
+  const handleFocus = () => {
+    setHistory(getQueryHistory());
+    setShowHistory(true);
+  };
+
+  const handleBlur = () => {
+    setTimeout(() => setShowHistory(false), 100);
+  };
 
   useEffect(() => {
     const el = inputRef.current;
@@ -50,6 +61,8 @@ export default function SearchBar({ initialQuery = "", compact = false, onSearch
           placeholder="Ask AI anything..."
           value={query}
           onChange={(e) => setQuery(e.target.value)}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
           onKeyDown={(e) => {
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
@@ -84,6 +97,37 @@ export default function SearchBar({ initialQuery = "", compact = false, onSearch
             </Button>
           )}
         </div>
+        {showHistory && history.length > 0 && (
+          <div className="absolute left-0 top-full mt-2 w-full z-50 bg-card border border-border rounded-md shadow-lg">
+            {history.map((item) => (
+              <button
+                key={item}
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  setQuery(item);
+                  setShowHistory(false);
+                  onSearch(item);
+                }}
+                className="w-full text-left px-4 py-2 text-sm hover:bg-muted"
+              >
+                {item}
+              </button>
+            ))}
+            <button
+              type="button"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => {
+                clearQueryHistory();
+                setHistory([]);
+                setShowHistory(false);
+              }}
+              className="w-full text-left px-4 py-2 text-sm border-t hover:bg-muted"
+            >
+              Clear history
+            </button>
+          </div>
+        )}
       </div>
     </form>
   );

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -99,3 +99,40 @@ export function getRandomSuggestions(count: number = 3): string[] {
   const shuffled = [...searchSuggestions].sort(() => 0.5 - Math.random());
   return shuffled.slice(0, count);
 }
+
+/** Key used to store query history in localStorage. */
+const QUERY_HISTORY_KEY = "queryHistory";
+
+/**
+ * Retrieve past search queries from localStorage.
+ */
+export function getQueryHistory(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const data = window.localStorage.getItem(QUERY_HISTORY_KEY);
+    return data ? (JSON.parse(data) as string[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Save a new query to localStorage, keeping only the most recent 10.
+ */
+export function saveQueryToHistory(query: string, limit = 10): void {
+  if (typeof window === "undefined") return;
+  const history = getQueryHistory().filter((q) => q !== query);
+  history.unshift(query);
+  window.localStorage.setItem(
+    QUERY_HISTORY_KEY,
+    JSON.stringify(history.slice(0, limit)),
+  );
+}
+
+/**
+ * Clear all stored search history.
+ */
+export function clearQueryHistory(): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(QUERY_HISTORY_KEY);
+}

--- a/client/src/pages/SearchResults.tsx
+++ b/client/src/pages/SearchResults.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { searchAIStream, ModelResponse, SearchStreamEvent } from "@/lib/openrouter";
-import { formatSearchTime } from "@/lib/utils";
+import { formatSearchTime, saveQueryToHistory } from "@/lib/utils";
 import ResultCard from "@/components/ResultCard";
 import ModelFilterPills from "@/components/ModelFilterPills";
 import LoadingSkeleton from "@/components/LoadingSkeleton";
@@ -41,6 +41,7 @@ export default function SearchResults() {
       } else if (evt.type === "done") {
         setTotalTime(evt.data.totalTime);
         setIsLoading(false);
+        saveQueryToHistory(query);
       } else if (evt.type === "error") {
         setError(new Error(evt.data?.message || "Stream error"));
         setIsLoading(false);


### PR DESCRIPTION
## Summary
- support storing query history in `utils`
- show prior queries in a dropdown in `SearchBar`
- persist new queries after successful searches

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_683a07f2ce588320a955df7070df90f4