### PR TITLE
Fix AISearch references

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
-    <meta name="description" content="AI Search Engine - Compare results from different AI models in one search. Find the best AI answers to your questions." />
+    <meta name="description" content="VistAI Search Engine - Compare results from different AI models in one search. Find the best AI answers to your questions." />
     <title>VistAI - Multi-LLM Search Engine</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -639,8 +639,8 @@ async function queryOpenRouter(prompt, modelId, apiKey) {
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${apiKey}`,
-        'HTTP-Referer': 'https://aisearch.example',
-        'X-Title': 'AI Search Engine',
+        'HTTP-Referer': 'https://vistai.example',
+        'X-Title': 'VistAI Search Engine',
       },
       body: JSON.stringify({
         model: modelId,


### PR DESCRIPTION
## Summary
- rename AISearch mentions to VistAI

## Testing
- `npm test` *(fails: popular and recent queries)*
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_683a10aeab308320bbbfba36e973b291