### PR TITLE
Fix API link to /docs page

### DIFF
--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -19,7 +19,7 @@ export default function Footer() {
           <div className="flex items-center gap-4 text-sm text-muted-foreground">
             <Link href="/" className="hover:text-primary">Home</Link>
             <Link href="/dashboard" className="hover:text-primary">Dashboard</Link>
-            <Link href="/docs" className="hover:text-primary">API</Link>
+            <a href="/docs" className="hover:text-primary">API</a>
             <button className="hover:text-primary">Pricing</button>
             <button className="hover:text-primary">Contact</button>
           </div>


### PR DESCRIPTION
## Summary
- use a normal anchor tag for the API link in the footer

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_683b9338c00c832099da7659ddd948d7