### PR TITLE
Add trending query section on home page

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { getRandomSuggestions } from "@/lib/utils";
+import { getRandomSuggestions, fetchPopularQueries } from "@/lib/utils";
 import SearchBar from "@/components/SearchBar";
 import { Link, useLocation } from "wouter";
 
@@ -9,9 +9,17 @@ import { Link, useLocation } from "wouter";
 export default function Home() {
   const [, navigate] = useLocation();
   const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [isTrending, setIsTrending] = useState(false);
 
   useEffect(() => {
-    getRandomSuggestions(3).then(setSuggestions);
+    fetchPopularQueries(5).then((qs) => {
+      if (qs.length > 0) {
+        setIsTrending(true);
+        setSuggestions(qs);
+      } else {
+        getRandomSuggestions(3).then(setSuggestions);
+      }
+    });
   }, []);
 
   const handleSearch = (query: string) => {
@@ -32,17 +40,34 @@ export default function Home() {
       <div className="w-full max-w-2xl mx-auto">
         <SearchBar onSearch={handleSearch} />
 
-        <div className="flex flex-wrap justify-center gap-2 mt-5">
-          {suggestions.map((suggestion, index) => (
-            <button 
-              key={index} 
-              className="text-xs bg-card px-3 py-1.5 rounded-full text-muted-foreground cursor-pointer hover:bg-card/80 transition-colors"
-              onClick={() => handleSearch(suggestion)}
-            >
-              Try: "{suggestion}"
-            </button>
-          ))}
-        </div>
+        {isTrending ? (
+          <div className="mt-5 text-center">
+            <h2 className="text-sm font-medium mb-2">Trending searches</h2>
+            <div className="flex flex-wrap justify-center gap-2">
+              {suggestions.map((suggestion) => (
+                <Link
+                  key={suggestion}
+                  href={`/search?q=${encodeURIComponent(suggestion)}`}
+                  className="text-xs bg-card px-3 py-1.5 rounded-full text-muted-foreground hover:bg-card/80 transition-colors"
+                >
+                  {suggestion}
+                </Link>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="flex flex-wrap justify-center gap-2 mt-5">
+            {suggestions.map((suggestion, index) => (
+              <button
+                key={index}
+                className="text-xs bg-card px-3 py-1.5 rounded-full text-muted-foreground cursor-pointer hover:bg-card/80 transition-colors"
+                onClick={() => handleSearch(suggestion)}
+              >
+                {`Try: "${suggestion}"`}
+              </button>
+            ))}
+          </div>
+        )}
 
         <div className="mt-16 text-center">
           <p className="text-muted-foreground text-sm">


### PR DESCRIPTION
## Summary
- show popular queries in `Home.tsx` via `fetchPopularQueries`
- fall back to random suggestions when API returns no data
- fix button label for fallback suggestions

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_683b92eb3a208320b1356f54d799cad0