### PR TITLE
Add persistent auth and logout

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import Dashboard from "@/pages/Dashboard";
 import Settings from "@/pages/Settings";
 import Login from "@/pages/Login";
 import Register from "@/pages/Register";
+import Logout from "@/pages/Logout";
 import NotFound from "@/pages/not-found";
 import "./index.css";
 
@@ -25,6 +26,7 @@ export default function App() {
           <Route path="/settings" component={Settings} />
           <Route path="/login" component={Login} />
           <Route path="/register" component={Register} />
+          <Route path="/logout" component={Logout} />
           <Route component={NotFound} />
         </Switch>
       </main>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -2,6 +2,14 @@ import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import SearchBar from "./SearchBar";
 import { Link, useLocation } from "wouter";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/useAuth";
 
 /**
  * Sticky page header containing navigation and the search bar.
@@ -10,6 +18,7 @@ export default function Header() {
   const [scrolled, setScrolled] = useState(false);
   const [location, navigate] = useLocation();
   const isHomePage = location === "/";
+  const { user, logout } = useAuth();
   
   // Detect scroll for styling
   useEffect(() => {
@@ -56,13 +65,41 @@ export default function Header() {
               <i className="ri-dashboard-line text-xl"></i>
               <span className="sr-only">Dashboard</span>
             </Link>
-            
-            <button 
-              className="ml-2 w-8 h-8 rounded-full bg-primary/20 flex items-center justify-center text-primary hover:bg-primary/30 transition-colors"
-            >
-              <i className="ri-user-line"></i>
-              <span className="sr-only">Account</span>
-            </button>
+
+            {user ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button className="ml-2 w-8 h-8 rounded-full bg-primary/20 text-primary hover:bg-primary/30 p-0">
+                    <i className="ri-user-line"></i>
+                    <span className="sr-only">Account</span>
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem disabled>{user.username}</DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => navigate('/settings')}>
+                    Settings
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => logout()}>
+                    Logout
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : (
+              <>
+                <Link
+                  href="/login"
+                  className="text-muted-foreground hover:text-foreground text-sm"
+                >
+                  Login
+                </Link>
+                <Link
+                  href="/register"
+                  className="text-muted-foreground hover:text-foreground text-sm"
+                >
+                  Register
+                </Link>
+              </>
+            )}
           </nav>
         </div>
       </div>

--- a/client/src/hooks/useAuth.tsx
+++ b/client/src/hooks/useAuth.tsx
@@ -1,0 +1,63 @@
+import * as React from "react"
+
+interface AuthUser {
+  id: number
+  username: string
+}
+
+interface AuthContextValue {
+  user: AuthUser | null
+  token: string | null
+  login: (token: string, user: AuthUser) => void
+  logout: () => void
+}
+
+function readStorage() {
+  if (typeof window === "undefined") return { token: null, user: null }
+  const token = window.localStorage.getItem("token")
+  const userStr = window.localStorage.getItem("user")
+  return { token, user: userStr ? (JSON.parse(userStr) as AuthUser) : null }
+}
+
+const AuthContext = React.createContext<AuthContextValue | undefined>(undefined)
+
+/**
+ * Provider and hook to access authentication state stored in localStorage.
+ */
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [{ token, user }, setState] = React.useState(readStorage())
+
+  const login = React.useCallback((t: string, u: AuthUser) => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("token", t)
+      window.localStorage.setItem("user", JSON.stringify(u))
+    }
+    setState({ token: t, user: u })
+  }, [])
+
+  const logout = React.useCallback(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.removeItem("token")
+      window.localStorage.removeItem("user")
+    }
+    setState({ token: null, user: null })
+  }, [])
+
+  const value = React.useMemo(
+    () => ({ token, user, login, logout }),
+    [token, user, login, logout],
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+/**
+ * React hook exposing auth context.
+ */
+export function useAuth() {
+  const ctx = React.useContext(AuthContext)
+  if (!ctx) {
+    throw new Error("useAuth must be used within AuthProvider")
+  }
+  return ctx
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -5,15 +5,18 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "./lib/queryClient";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/toaster";
+import { AuthProvider } from "@/hooks/useAuth";
 import App from "./App";
 import "./index.css";
 
 createRoot(document.getElementById("root")!).render(
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
-      <Router searchHook={useLocationSearch}>
-        <App />
-      </Router>
+      <AuthProvider>
+        <Router searchHook={useLocationSearch}>
+          <App />
+        </Router>
+      </AuthProvider>
       <Toaster />
     </TooltipProvider>
   </QueryClientProvider>

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -4,9 +4,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useLocation } from "wouter";
+import { useAuth } from "@/hooks/useAuth";
 
 interface AuthResponse {
   token: string;
+  user: { id: number; username: string };
 }
 
 /**
@@ -14,6 +16,7 @@ interface AuthResponse {
  */
 export default function Login() {
   const [, navigate] = useLocation();
+  const { login } = useAuth();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -24,9 +27,7 @@ export default function Login() {
     try {
       const res = await apiRequest("POST", "/api/login", { username, password });
       const data: AuthResponse = await res.json();
-      if (typeof window !== "undefined") {
-        window.localStorage.setItem("token", data.token);
-      }
+      login(data.token, data.user);
       navigate("/");
     } catch (err: any) {
       setError(err.message || "Login failed");

--- a/client/src/pages/Logout.tsx
+++ b/client/src/pages/Logout.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from "react"
+import { useLocation } from "wouter"
+import { useAuth } from "@/hooks/useAuth"
+
+/**
+ * Page that logs the user out and redirects to home.
+ */
+export default function Logout() {
+  const { logout } = useAuth()
+  const [, navigate] = useLocation()
+
+  useEffect(() => {
+    logout()
+    navigate("/")
+  }, [logout, navigate])
+
+  return null
+}

--- a/client/src/pages/Register.tsx
+++ b/client/src/pages/Register.tsx
@@ -4,9 +4,11 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useLocation } from "wouter";
+import { useAuth } from "@/hooks/useAuth";
 
 interface AuthResponse {
   token: string;
+  user: { id: number; username: string };
 }
 
 /**
@@ -14,6 +16,7 @@ interface AuthResponse {
  */
 export default function Register() {
   const [, navigate] = useLocation();
+  const { login } = useAuth();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -24,9 +27,7 @@ export default function Register() {
     try {
       const res = await apiRequest("POST", "/api/register", { username, password });
       const data: AuthResponse = await res.json();
-      if (typeof window !== "undefined") {
-        window.localStorage.setItem("token", data.token);
-      }
+      login(data.token, data.user);
       navigate("/");
     } catch (err: any) {
       setError(err.message || "Registration failed");

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,33 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+import worker from '../worker/worker.js'
+import { FakeD1Database } from './fake-db.js'
+
+/** Ensure register/login return signed JWT tokens. */
+test('authentication tokens are signed', async () => {
+  const db = new FakeD1Database()
+  const env = { DB: db, OPENROUTER_API_KEY: 'k', JWT_SECRET: 'secret' }
+
+  const regReq = new Request('http://localhost/api/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'u', password: 'p' }),
+  })
+  const regRes = await worker.fetch(regReq, env)
+  const reg = await regRes.json()
+  const [h, b, s] = reg.token.split('.')
+  const expected = crypto.createHmac('sha256', env.JWT_SECRET).update(`${h}.${b}`).digest('base64url')
+  assert.strictEqual(s, expected)
+  const payload = JSON.parse(Buffer.from(b, 'base64url').toString())
+  assert.strictEqual(payload.userId, 1)
+
+  const loginReq = new Request('http://localhost/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'u', password: 'p' }),
+  })
+  const loginRes = await worker.fetch(loginReq, env)
+  const { token } = await loginRes.json()
+  assert.ok(token && token.split('.').length === 3)
+})

--- a/tests/track-click.test.ts
+++ b/tests/track-click.test.ts
@@ -20,7 +20,7 @@ test('track-click updates model stats with percentages', async () => {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ username: 'u', password: 'p' }),
   });
-  const registerRes = await worker.fetch(registerReq, { DB: db, OPENROUTER_API_KEY: 'key' });
+  const registerRes = await worker.fetch(registerReq, { DB: db, OPENROUTER_API_KEY: 'key', JWT_SECRET: 'secret' });
   const { token } = await registerRes.json();
 
   const search = await createSearch(db as any, { query: 'q' });
@@ -45,7 +45,7 @@ test('track-click updates model stats with percentages', async () => {
     body: JSON.stringify({ resultId: resultB.id }),
   });
 
-  const res = await worker.fetch(req, { DB: db, OPENROUTER_API_KEY: 'key' });
+  const res = await worker.fetch(req, { DB: db, OPENROUTER_API_KEY: 'key', JWT_SECRET: 'secret' });
   assert.strictEqual(res.status, 200);
   const data = await res.json();
   assert.ok(data.success);


### PR DESCRIPTION
## Summary
- add `useAuth` hook for persisted auth state
- expose logout page and show dropdown when logged in
- issue signed JWTs from worker and verify on requests
- cover auth with unit tests

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_683b92eab1208320b30e4c550eb6b8b3