### PR TITLE
Add custom OpenRouter key option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ Open `dist/public/index.html` in your browser to test locally.
 - **Performance Tracking**: See which models respond fastest and are chosen most often
 - **User Accounts**: Register and log in to track personal model preferences
 - **Voice Search**: Click the microphone to dictate your question
+- **Custom API Key**: Use the default key or specify your own in Settings
 
 ## Environment Variables
 
 Set `OPENROUTER_API_KEY` as a secret when deploying the Cloudflare worker.
+The worker will use this key unless you provide your own from the Settings page.
 Use `ACCESS_CONTROL_ALLOW_ORIGIN` to control which origins may access the Worker
 APIs. Provide `*` to allow any origin or a comma separated list of allowed
 origins.

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -34,6 +34,10 @@ export async function apiRequest(
       ...(typeof window !== "undefined" && window.localStorage?.getItem("token")
         ? { Authorization: `Bearer ${window.localStorage.getItem("token")}` }
         : {}),
+      ...(typeof window !== "undefined" &&
+      window.localStorage?.getItem("openrouter_api_key")
+        ? { "openrouter_api_key": String(window.localStorage.getItem("openrouter_api_key")) }
+        : {}),
       ...(options?.headers || {}),
     },
     body: data ? JSON.stringify(data) : undefined,

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 
 /**
  * Settings page for managing user preferences.
  */
 export default function Settings() {
   const [darkMode, setDarkMode] = useState(false);
+  const [apiKey, setApiKey] = useState("");
 
   // Initialize theme from localStorage
   useEffect(() => {
@@ -15,6 +18,13 @@ export default function Settings() {
     const prefersDark =
       stored === "dark" || (!stored && window.matchMedia("(prefers-color-scheme: dark)").matches);
     setDarkMode(prefersDark);
+  }, []);
+
+  // Initialize API key from localStorage
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const storedKey = window.localStorage.getItem("openrouter_api_key") || "";
+    setApiKey(storedKey);
   }, []);
 
   // Apply theme when darkMode changes
@@ -46,6 +56,31 @@ export default function Settings() {
             <span className="text-sm">Dark Mode</span>
             <Switch checked={darkMode} onCheckedChange={setDarkMode} />
           </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>OpenRouter API Key</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input
+            placeholder="sk-..."
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+          />
+          <Button
+            onClick={() => {
+              if (typeof window === "undefined") return;
+              if (apiKey) {
+                window.localStorage.setItem("openrouter_api_key", apiKey);
+              } else {
+                window.localStorage.removeItem("openrouter_api_key");
+              }
+            }}
+          >
+            Save
+          </Button>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- allow storing a user OpenRouter API key in Settings
- send that key on API requests when present
- document the new capability in the README

## Testing
- `npm test`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_683c65eedd2c8320bb679c27de2f48eb