### PR TITLE
Improve password hashing security

### DIFF
--- a/worker/db.js
+++ b/worker/db.js
@@ -1,8 +1,30 @@
 import crypto from 'node:crypto';
 
-/** Hash a plain text password using SHA-256. */
+/**
+ * Hash a plain text password using PBKDF2 with SHA-256 and a random salt.
+ * Returns a string in the format `salt:hash` where both values are hex encoded.
+ */
 export function hashPassword(password) {
-  return crypto.createHash('sha256').update(password).digest('hex');
+  const salt = crypto.randomBytes(16).toString('hex');
+  const hash = crypto
+    .pbkdf2Sync(password, salt, 100000, 32, 'sha256')
+    .toString('hex');
+  return `${salt}:${hash}`;
+}
+
+/**
+ * Verify a plain text password against a stored `salt:hash` string.
+ */
+export function verifyPassword(password, stored) {
+  const [salt, hash] = stored.split(':');
+  if (!salt || !hash) return false;
+  const hashed = crypto
+    .pbkdf2Sync(password, salt, 100000, 32, 'sha256')
+    .toString('hex');
+  return crypto.timingSafeEqual(
+    Buffer.from(hashed, 'hex'),
+    Buffer.from(hash, 'hex'),
+  );
 }
 
 /** Create a user and return the new record. */

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -11,6 +11,7 @@ import {
   findUser,
   findUserById,
   hashPassword,
+  verifyPassword,
 } from './db.js';
 import crypto from 'node:crypto';
 
@@ -437,7 +438,7 @@ export default {
           return jsonResponse({ message: 'Invalid credentials' }, headers, 400);
         }
         const user = await findUser(env.DB, username);
-        if (!user || hashPassword(password) !== user.password) {
+        if (!user || !verifyPassword(password, user.password)) {
           return jsonResponse({ message: 'Invalid credentials' }, headers, 401);
         }
         const secret = env.JWT_SECRET || 'secret';


### PR DESCRIPTION
## Summary
- switch password hashing to salted PBKDF2
- add helper to verify passwords
- update login logic to use new verification method

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_683c7563af28832087f8544e381a9d81