### PR TITLE
Remove custom OpenRouter API key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,11 @@ Open `dist/public/index.html` in your browser to test locally.
 - **Performance Tracking**: See which models respond fastest and are chosen most often
 - **User Accounts**: Register and log in to track personal model preferences
 - **Voice Search**: Click the microphone to dictate your question
-- **Custom API Key**: Use the default key or specify your own in Settings
 
 ## Environment Variables
 
 Set `OPENROUTER_API_KEY` as a secret when deploying the Cloudflare worker.
-The worker will use this key unless you provide your own from the Settings page.
+The worker uses this server-side key exclusively.
 Use `ACCESS_CONTROL_ALLOW_ORIGIN` to control which origins may access the Worker
 APIs. Provide `*` to allow any origin or a comma separated list of allowed
 origins.

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -34,10 +34,7 @@ export async function apiRequest(
       ...(typeof window !== "undefined" && window.localStorage?.getItem("token")
         ? { Authorization: `Bearer ${window.localStorage.getItem("token")}` }
         : {}),
-      ...(typeof window !== "undefined" &&
-      window.localStorage?.getItem("openrouter_api_key")
-        ? { "openrouter_api_key": String(window.localStorage.getItem("openrouter_api_key")) }
-        : {}),
+      // Removed custom OpenRouter API key header for security
       ...(options?.headers || {}),
     },
     body: data ? JSON.stringify(data) : undefined,

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -1,15 +1,12 @@
 import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
 
 /**
  * Settings page for managing user preferences.
  */
 export default function Settings() {
   const [darkMode, setDarkMode] = useState(false);
-  const [apiKey, setApiKey] = useState("");
 
   // Initialize theme from localStorage
   useEffect(() => {
@@ -20,12 +17,6 @@ export default function Settings() {
     setDarkMode(prefersDark);
   }, []);
 
-  // Initialize API key from localStorage
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const storedKey = window.localStorage.getItem("openrouter_api_key") || "";
-    setApiKey(storedKey);
-  }, []);
 
   // Apply theme when darkMode changes
   useEffect(() => {
@@ -59,30 +50,6 @@ export default function Settings() {
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>OpenRouter API Key</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <Input
-            placeholder="sk-..."
-            value={apiKey}
-            onChange={(e) => setApiKey(e.target.value)}
-          />
-          <Button
-            onClick={() => {
-              if (typeof window === "undefined") return;
-              if (apiKey) {
-                window.localStorage.setItem("openrouter_api_key", apiKey);
-              } else {
-                window.localStorage.removeItem("openrouter_api_key");
-              }
-            }}
-          >
-            Save
-          </Button>
-        </CardContent>
-      </Card>
     </div>
   );
 }

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -54,12 +54,7 @@ const openapiSpec = `openapi: 3.0.0
 info:
   title: VistAI API
   version: '1.0.0'
-components:
-  securitySchemes:
-    openrouter_api_key:
-      type: apiKey
-      in: header
-      name: openrouter_api_key
+components: {}
 paths:
   /api/status:
     get:
@@ -135,8 +130,6 @@ paths:
   /api/search:
     post:
       summary: Query models
-      security:
-        - openrouter_api_key: []
       requestBody:
         required: true
         content:
@@ -330,11 +323,6 @@ const swaggerHtml = `<!DOCTYPE html>
   <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css">
 </head>
 <body>
-  <div style="margin:10px">
-    OpenRouter API Key:
-    <input id="or-key" type="text" style="width:300px" />
-    <button onclick="setKey()">Set</button>
-  </div>
   <div id="swagger-ui"></div>
   <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
   <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-standalone-preset.js"></script>
@@ -346,18 +334,6 @@ const swaggerHtml = `<!DOCTYPE html>
       presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
       layout: 'StandaloneLayout'
     });
-    const stored = localStorage.getItem('openrouter_api_key');
-    if (stored) {
-      ui.preauthorizeApiKey('openrouter_api_key', stored);
-      document.getElementById('or-key').value = stored;
-    }
-    window.setKey = () => {
-      const k = document.getElementById('or-key').value;
-      if (k) {
-        localStorage.setItem('openrouter_api_key', k);
-        ui.preauthorizeApiKey('openrouter_api_key', k);
-      }
-    };
   };
   </script>
 </body>
@@ -376,8 +352,7 @@ export default {
     // Basic CORS support with configurable origins
     const headers = createCorsHeaders(request, env);
 
-    const requestApiKey = request.headers.get('openrouter_api_key');
-    const apiKey = requestApiKey || env.OPENROUTER_API_KEY;
+    const apiKey = env.OPENROUTER_API_KEY;
 
     if (!apiKey) {
       return jsonResponse({ message: 'OPENROUTER_API_KEY is missing' }, headers, 500);
@@ -602,7 +577,7 @@ export default {
     return {
       'Access-Control-Allow-Origin': allow,
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type, openrouter_api_key',
+      'Access-Control-Allow-Headers': 'Content-Type',
       'Vary': 'Origin',
     };
   }


### PR DESCRIPTION
## Summary
- stop storing API keys on the client
- remove API key header support from the worker
- clean up Settings page UI
- document server-side API key usage only

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_683c757272748320a3dc54c07719e38d