### PR TITLE
Fix CORS default handling

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -83,7 +83,7 @@ wrangler pages deploy dist/public
 - `JWT_SECRET` - Secret for JWT token signing (generates random if not set)
 
 ### Optional Variables (Worker)
-- `ACCESS_CONTROL_ALLOW_ORIGIN` - CORS configuration (defaults to "*")
+- `ACCESS_CONTROL_ALLOW_ORIGIN` - CORS configuration. Set a comma separated list of allowed origins or `*` for development. If unset, cross-origin requests are blocked.
 
 ### Required Variables (Frontend - Cloudflare Pages)
 - `API_BASE_URL` - Your worker URL for API requests
@@ -126,9 +126,9 @@ wrangler secret put OPENROUTER_API_KEY --env production
    - Verify database_id in wrangler.toml matches your D1 database
    - Run migrations: `wrangler d1 migrations apply vistai`
 
-2. **CORS errors**  
+2. **CORS errors**
    - Set `ACCESS_CONTROL_ALLOW_ORIGIN` to your frontend URL
-   - For development, use "*"
+   - For development, you may use "*"
 
 3. **API key errors**
    - Ensure `OPENROUTER_API_KEY` is set as a secret

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Open `dist/public/index.html` in your browser to test locally.
 Set `OPENROUTER_API_KEY` as a secret when deploying the Cloudflare worker.
 The worker will use this key unless you provide your own from the Settings page.
 Use `ACCESS_CONTROL_ALLOW_ORIGIN` to control which origins may access the Worker
-APIs. Provide `*` to allow any origin or a comma separated list of allowed
-origins.
+APIs. By default no cross-origin requests are allowed. Provide `*` for
+development or a comma separated list of allowed origins.
 
 ## D1 Database
 

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -597,22 +597,23 @@ export default {
   }
 
   function createCorsHeaders(request, env) {
-    const cfg = env.ACCESS_CONTROL_ALLOW_ORIGIN || '*';
+    const cfg = env.ACCESS_CONTROL_ALLOW_ORIGIN || '';
+    if (!cfg) {
+      return {};
+    }
     const allowed = cfg.split(',').map((o) => o.trim()).filter(Boolean);
     const origin = request.headers.get('Origin') || '';
-    let allow = '*';
-    if (!allowed.includes('*')) {
-      if (origin && allowed.includes(origin)) {
-        allow = origin;
-      } else {
-        allow = allowed[0] || 'null';
-      }
+    let allow = allowed[0] || 'null';
+    if (allowed.includes('*')) {
+      allow = '*';
+    } else if (origin && allowed.includes(origin)) {
+      allow = origin;
     }
     return {
       'Access-Control-Allow-Origin': allow,
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type, openrouter_api_key',
-      'Vary': 'Origin',
+      Vary: 'Origin',
     };
   }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,7 +5,7 @@ compatibility_flags = ["nodejs_compat"]
 
 [vars]
 # Environment variables can be set in Cloudflare dashboard or via wrangler secret put
-# ACCESS_CONTROL_ALLOW_ORIGIN = "*"  # For development, restrict in production
+# ACCESS_CONTROL_ALLOW_ORIGIN = "*"  # Use only for development; set specific origins in production
 # JWT_SECRET = "your-secure-jwt-secret-here"  # Set via wrangler secret put JWT_SECRET
 
 [observability]


### PR DESCRIPTION
## Summary
- restrict CORS behaviour in worker
- clarify CORS instructions in README and deployment docs
- warn in wrangler.toml that `*` is dev-only

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_683c7577ef3c8320a3672e6d3401d211