### PR TITLE
Use http-only cookies for auth

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -31,9 +31,6 @@ export async function apiRequest(
     method,
     headers: {
       ...(data ? { "Content-Type": "application/json" } : {}),
-      ...(typeof window !== "undefined" && window.localStorage?.getItem("token")
-        ? { Authorization: `Bearer ${window.localStorage.getItem("token")}` }
-        : {}),
       ...(typeof window !== "undefined" &&
       window.localStorage?.getItem("openrouter_api_key")
         ? { "openrouter_api_key": String(window.localStorage.getItem("openrouter_api_key")) }

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -15,8 +15,9 @@ test('authentication tokens are signed', async () => {
     body: JSON.stringify({ username: 'u', password: 'p' }),
   })
   const regRes = await worker.fetch(regReq, env)
-  const reg = await regRes.json()
-  const [h, b, s] = reg.token.split('.')
+  const cookie = regRes.headers.get('Set-Cookie') || ''
+  const token = cookie.split('token=')[1]?.split(';')[0] || ''
+  const [h, b, s] = token.split('.')
   const expected = crypto.createHmac('sha256', env.JWT_SECRET).update(`${h}.${b}`).digest('base64url')
   assert.strictEqual(s, expected)
   const payload = JSON.parse(Buffer.from(b, 'base64url').toString())
@@ -28,6 +29,7 @@ test('authentication tokens are signed', async () => {
     body: JSON.stringify({ username: 'u', password: 'p' }),
   })
   const loginRes = await worker.fetch(loginReq, env)
-  const { token } = await loginRes.json()
-  assert.ok(token && token.split('.').length === 3)
+  const loginCookie = loginRes.headers.get('Set-Cookie') || ''
+  const loginToken = loginCookie.split('token=')[1]?.split(';')[0] || ''
+  assert.ok(loginToken && loginToken.split('.').length === 3)
 })

--- a/tests/track-click.test.ts
+++ b/tests/track-click.test.ts
@@ -21,7 +21,8 @@ test('track-click updates model stats with percentages', async () => {
     body: JSON.stringify({ username: 'u', password: 'p' }),
   });
   const registerRes = await worker.fetch(registerReq, { DB: db, OPENROUTER_API_KEY: 'key', JWT_SECRET: 'secret' });
-  const { token } = await registerRes.json();
+  const cookie = registerRes.headers.get('Set-Cookie') || '';
+  const token = cookie.split('token=')[1]?.split(';')[0] || '';
 
   const search = await createSearch(db as any, { query: 'q' });
   await createResult(db as any, {

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -42,12 +42,29 @@ function verifyToken(token, secret) {
     const [h, b, s] = token.split('.');
     if (!h || !b || !s) return null;
     const data = `${h}.${b}`;
-    const expected = crypto.createHmac('sha256', secret).update(data).digest('base64url');
+    const expected = crypto
+      .createHmac('sha256', secret)
+      .update(data)
+      .digest('base64url');
     if (s !== expected) return null;
     return JSON.parse(Buffer.from(b, 'base64url').toString('utf8'));
   } catch {
     return null;
   }
+}
+
+function getTokenFromRequest(request) {
+  const auth = request.headers.get('Authorization') || '';
+  const m = auth.match(/^Bearer\s+(.*)$/);
+  if (m) return m[1];
+  const cookie = request.headers.get('Cookie') || '';
+  const ck = cookie.split(';').find((c) => c.trim().startsWith('token='));
+  return ck ? ck.trim().slice('token='.length) : '';
+}
+
+function tokenCookie(token) {
+  const week = 7 * 24 * 60 * 60;
+  return `token=${token}; HttpOnly; Path=/; Max-Age=${week}`;
 }
 
 const openapiSpec = `openapi: 3.0.0
@@ -102,13 +119,11 @@ paths:
               schema:
                 type: object
                 properties:
-                  token:
-                    type: string
                   user:
                     type: object
   /api/login:
     post:
-      summary: Login and obtain auth token
+      summary: Login and obtain auth cookie
       requestBody:
         required: true
         content:
@@ -128,10 +143,21 @@ paths:
               schema:
                 type: object
                 properties:
-                  token:
-                    type: string
                   user:
                     type: object
+  /api/logout:
+    post:
+      summary: Clear authentication cookie
+      responses:
+        '200':
+          description: Logout success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
   /api/search:
     post:
       summary: Query models
@@ -430,7 +456,10 @@ export default {
           return jsonResponse({ message: 'JWT_SECRET is not set' }, headers, 500);
         }
         const token = signToken({ userId: user.id }, secret);
-        return jsonResponse({ token, user }, headers);
+        return jsonResponse(
+          { user },
+          { ...headers, 'Set-Cookie': tokenCookie(token) },
+        );
       }
 
       if (pathname === '/api/login' && request.method === 'POST') {
@@ -448,25 +477,30 @@ export default {
           return jsonResponse({ message: 'JWT_SECRET is not set' }, headers, 500);
         }
         const token = signToken({ userId: user.id }, secret);
-        return jsonResponse({ token, user: { id: user.id, username: user.username } }, headers);
+        return jsonResponse(
+          { user: { id: user.id, username: user.username } },
+          { ...headers, 'Set-Cookie': tokenCookie(token) },
+        );
       }
 
       if (pathname === '/api/me' && request.method === 'GET') {
-        const auth = request.headers.get('Authorization') || '';
-        const m = auth.match(/^Bearer\s+(.*)$/);
-        const token = m ? m[1] : '';
-        const userId = tokenMap.get(token);
-        
+        const secret = env.JWT_SECRET;
+        if (!secret) {
+          return jsonResponse({ message: 'JWT_SECRET is not set' }, headers, 500);
+        }
+        const token = getTokenFromRequest(request);
+        const payload = verifyToken(token, secret);
+        const userId = payload ? payload.userId : undefined;
+
         if (!userId) {
           return jsonResponse({ message: 'Invalid token' }, headers, 401);
         }
-        
-        // Get user data from database
+
         const user = await findUserById(env.DB, userId);
         if (!user) {
           return jsonResponse({ message: 'User not found' }, headers, 404);
         }
-        
+
         return jsonResponse({ id: user.id, username: user.username }, headers);
       }
 
@@ -544,19 +578,24 @@ export default {
         if (typeof resultId !== 'number') {
           return jsonResponse({ message: 'Invalid click data' }, headers, 400);
         }
-        const auth = request.headers.get('Authorization') || '';
-        const m = auth.match(/^Bearer\s+(.*)$/);
-        const token = m ? m[1] : '';
         const secret = env.JWT_SECRET;
         if (!secret) {
           return jsonResponse({ message: 'JWT_SECRET is not set' }, headers, 500);
         }
+        const token = getTokenFromRequest(request);
         const payload = verifyToken(token, secret);
         const userId = payload ? payload.userId : undefined;
 
         const click = await trackClick(env.DB, { resultId, userId });
         const stats = await getModelStatsWithPercent(env.DB);
         return jsonResponse({ success: true, click, stats }, headers);
+      }
+
+      if (pathname === '/api/logout' && request.method === 'POST') {
+        return jsonResponse(
+          { success: true },
+          { ...headers, 'Set-Cookie': 'token=; Path=/; Max-Age=0; HttpOnly' },
+        );
       }
 
       if (pathname === '/api/model-stats' && request.method === 'GET') {


### PR DESCRIPTION
## Summary
- store auth tokens as HTTP-only cookies on login and register
- adjust login/logout flow and AuthContext to rely on cookies instead of localStorage
- update API spec and worker to parse cookie tokens
- add `/api/logout` endpoint
- revise tests for new cookie-based auth

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683c756aaf2c8320afa8f0db4c824829