### PR TITLE
Add public dashboard page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import Footer from "@/components/Footer";
 import Home from "@/pages/Home";
 import SearchResults from "@/pages/SearchResults";
 import Dashboard from "@/pages/Dashboard";
+import PublicDashboard from "@/pages/PublicDashboard";
 import Settings from "@/pages/Settings";
 import Login from "@/pages/Login";
 import Register from "@/pages/Register";
@@ -23,6 +24,7 @@ export default function App() {
         <Switch>
           <Route path="/" component={Home} />
           <Route path="/search" component={SearchResults} />
+          <Route path="/dashboard-public" component={PublicDashboard} />
           <Route path="/dashboard">
             <ProtectedRoute>
               <Dashboard />

--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -1,10 +1,12 @@
 import { Link } from "wouter";
 import { Button } from "@/components/ui/button";
+import { useAuth } from "@/contexts/AuthContext";
 
 /**
  * Site footer with navigation links and OpenRouter attribution.
  */
 export default function Footer() {
+  const { isAuthenticated } = useAuth();
   return (
     <footer className="border-t border-border py-6 mt-auto">
       <div className="container mx-auto px-4">
@@ -19,7 +21,12 @@ export default function Footer() {
           
           <div className="flex items-center gap-4 text-sm text-muted-foreground">
             <Link href="/" className="hover:text-primary">Home</Link>
-            <Link href="/dashboard" className="hover:text-primary">Dashboard</Link>
+            <Link
+              href={isAuthenticated ? "/dashboard" : "/dashboard-public"}
+              className="hover:text-primary"
+            >
+              Dashboard
+            </Link>
             <a href="/docs" className="hover:text-primary">API</a>
             <button className="hover:text-primary">Pricing</button>
             <button className="hover:text-primary">Contact</button>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -58,9 +58,17 @@ export default function Header() {
           )}
           
           <nav className="flex items-center gap-3">
-            {isAuthenticated && (
+            {isAuthenticated ? (
               <Link
                 href="/dashboard"
+                className="text-muted-foreground hover:text-foreground transition-colors p-1"
+              >
+                <i className="ri-dashboard-line text-xl"></i>
+                <span className="sr-only">Dashboard</span>
+              </Link>
+            ) : (
+              <Link
+                href="/dashboard-public"
                 className="text-muted-foreground hover:text-foreground transition-colors p-1"
               >
                 <i className="ri-dashboard-line text-xl"></i>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -2,12 +2,14 @@ import { useState, useEffect } from "react";
 import { getRandomSuggestions, fetchPopularQueries } from "@/lib/utils";
 import SearchBar from "@/components/SearchBar";
 import { Link, useLocation } from "wouter";
+import { useAuth } from "@/contexts/AuthContext";
 
 /**
  * Landing page with search bar and example suggestions.
  */
 export default function Home() {
   const [, navigate] = useLocation();
+  const { isAuthenticated } = useAuth();
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [isTrending, setIsTrending] = useState(false);
 
@@ -72,8 +74,13 @@ export default function Home() {
 
         <div className="mt-16 text-center">
           <p className="text-muted-foreground text-sm">
-            Powered by <a href="https://openrouter.ai" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">OpenRouter</a> •
-            <Link href="/dashboard" className="text-muted-foreground hover:text-foreground ml-1">Dashboard</Link> •
+            Powered by <a href="https://openrouter.ai" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">OpenRouter</a> •{' '}
+            <Link
+              href={isAuthenticated ? "/dashboard" : "/dashboard-public"}
+              className="text-muted-foreground hover:text-foreground ml-1"
+            >
+              Dashboard
+            </Link>{' '}•{' '}
             <Link href="/settings" className="text-muted-foreground hover:text-foreground ml-1">Settings</Link>
           </p>
         </div>

--- a/client/src/pages/PublicDashboard.tsx
+++ b/client/src/pages/PublicDashboard.tsx
@@ -1,0 +1,6 @@
+import Dashboard from "./Dashboard";
+
+/**
+ * Public dashboard showing model statistics without requiring login.
+ */
+export default Dashboard;


### PR DESCRIPTION
## Summary
- create `PublicDashboard` page
- add `/dashboard-public` route
- link to public dashboard for unauthenticated users

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683c951f29bc83209c60717f8f30d232