### PR TITLE
Fix register button and enforce stronger passwords

### DIFF
--- a/API.md
+++ b/API.md
@@ -66,7 +66,7 @@ Create a new user account.
 ```json
 {
   "username": "string (3-50 chars, alphanumeric)",
-  "password": "string (6+ chars)"
+  "password": "string (8+ chars)"
 }
 ```
 

--- a/client/src/pages/Register.tsx
+++ b/client/src/pages/Register.tsx
@@ -57,14 +57,14 @@ export default function Register() {
             />
             <Input
               type="password"
-              placeholder="Password (min 6 characters)"
+              placeholder="Password (min 8 characters)"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
-              minLength={6}
+              minLength={8}
               disabled={isLoading}
             />
-            <Button type="submit" className="w-full" disabled={isLoading || !username || password.length < 6}>
+            <Button type="submit" className="w-full" disabled={isLoading || !username || password.length < 8}>
               {isLoading ? "Creating account..." : "Register"}
             </Button>
             <p className="text-center text-sm text-muted-foreground">

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -12,7 +12,7 @@ test('authentication tokens are signed', async () => {
   const regReq = new Request('http://localhost/api/register', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username: 'u', password: 'p' }),
+    body: JSON.stringify({ username: 'u', password: 'password123' }),
   })
   const regRes = await worker.fetch(regReq, env)
   const cookie = regRes.headers.get('Set-Cookie') || ''
@@ -26,7 +26,7 @@ test('authentication tokens are signed', async () => {
   const loginReq = new Request('http://localhost/api/login', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username: 'u', password: 'p' }),
+    body: JSON.stringify({ username: 'u', password: 'password123' }),
   })
   const loginRes = await worker.fetch(loginReq, env)
   const loginCookie = loginRes.headers.get('Set-Cookie') || ''

--- a/tests/track-click.test.ts
+++ b/tests/track-click.test.ts
@@ -18,7 +18,7 @@ test('track-click updates model stats with percentages', async () => {
   const registerReq = new Request('http://localhost/api/register', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username: 'u', password: 'p' }),
+    body: JSON.stringify({ username: 'u', password: 'password123' }),
   });
   const registerRes = await worker.fetch(registerReq, { DB: db, OPENROUTER_API_KEY: 'key', JWT_SECRET: 'secret' });
   const cookie = registerRes.headers.get('Set-Cookie') || '';

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -423,7 +423,7 @@ export default {
       if (pathname === '/api/register' && request.method === 'POST') {
         const body = await request.json();
         const { username, password } = body;
-        if (!username || !password) {
+        if (!username || !password || password.length < 8) {
           return jsonResponse({ message: 'Invalid user data' }, headers, 400);
         }
         const user = await createUser(env.DB, { username, password });


### PR DESCRIPTION
## Summary
- show min 8 characters for passwords on registration form
- enforce password length server-side
- update documentation and tests for new minimum length

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_683cccdf3e7083208d615a893c4ebb50