### PR TITLE
Fix search history overlap

### DIFF
--- a/client/src/components/SearchBar.tsx
+++ b/client/src/components/SearchBar.tsx
@@ -15,6 +15,8 @@ interface SearchBarProps {
   compact?: boolean;
   /** Callback function called when a search is submitted */
   onSearch: (query: string) => void;
+  /** Display search history as overlay dropdown */
+  overlayHistory?: boolean;
 }
 
 /**
@@ -47,7 +49,7 @@ const MAX_TEXTAREA_HEIGHT = 160;
  * />
  * ```
  */
-export default function SearchBar({ initialQuery = "", compact = false, onSearch }: SearchBarProps) {
+export default function SearchBar({ initialQuery = "", compact = false, onSearch, overlayHistory = true }: SearchBarProps) {
   const [query, setQuery] = useState(initialQuery);
   const [showHistory, setShowHistory] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -139,6 +141,7 @@ export default function SearchBar({ initialQuery = "", compact = false, onSearch
           show={showHistory}
           onSelect={handleHistorySelect}
           onToggle={setShowHistory}
+          overlay={overlayHistory}
         />
       </div>
     </form>

--- a/client/src/components/SearchHistory.tsx
+++ b/client/src/components/SearchHistory.tsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { getSearchHistory, clearSearchHistory } from "@/lib/utils";
+import { getSearchHistory, clearSearchHistory, cn } from "@/lib/utils";
 
 interface SearchHistoryProps {
   onSelect: (query: string) => void;
   show: boolean;
   onToggle: (show: boolean) => void;
+  /** Render as overlay dropdown instead of inline */
+  overlay?: boolean;
 }
 
 /**
@@ -15,7 +17,7 @@ interface SearchHistoryProps {
  * @param show - Whether to show the history dropdown
  * @param onToggle - Callback to control dropdown visibility
  */
-export function SearchHistory({ onSelect, show, onToggle }: SearchHistoryProps) {
+export function SearchHistory({ onSelect, show, onToggle, overlay = true }: SearchHistoryProps) {
   const [history, setHistory] = useState<string[]>([]);
 
   useEffect(() => {
@@ -49,7 +51,12 @@ export function SearchHistory({ onSelect, show, onToggle }: SearchHistoryProps) 
   }
 
   return (
-    <div className="absolute left-0 top-full mt-2 w-full z-50 bg-card border border-border rounded-md shadow-lg">
+    <div
+      className={cn(
+        overlay ? "absolute left-0 top-full mt-2 z-50" : "mt-2",
+        "w-full bg-card border border-border rounded-md shadow-lg"
+      )}
+    >
       {history.map((item) => (
         <Button
           key={item}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -63,7 +63,7 @@ export default function Home() {
       </div>
 
       <div className="w-full max-w-2xl mx-auto">
-        <SearchBar onSearch={handleSearch} />
+        <SearchBar onSearch={handleSearch} overlayHistory={false} />
 
         {isTrending ? (
           <div className="mt-5 text-center">


### PR DESCRIPTION
## Summary
- add `overlay` prop to `SearchHistory` so it can render inline
- allow `SearchBar` to pass `overlayHistory` option
- disable overlay on the home page search bar

## Testing
- `npm test`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_683e44bb1b90832082d0791212844eea