### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,5 +1,8 @@
 name: Deploy Cloudflare Worker
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]
@@ -21,4 +24,3 @@ jobs:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           command: deploy
-


### PR DESCRIPTION
Potential fix for [https://github.com/schmug/VistAI/security/code-scanning/1](https://github.com/schmug/VistAI/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the `contents: read` permission, which is the minimal permission required for most workflows. Since the workflow does not appear to require any other permissions, this change adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
